### PR TITLE
feat: brainstem neighborhood — peer registry + /api/peers + UI

### DIFF
--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -864,23 +864,59 @@ function Launch-Brainstem {
 
 # ── Project-local helpers (--here / RAPP_INSTALL_MODE=local) ─────────
 
+function Get-ClaimedPorts {
+    # Read the cross-install peer registry so back-to-back installs (where
+    # neither brainstem is running yet) don't both claim 7072.
+    $helper = Join-Path $BRAINSTEM_HOME "src\rapp_brainstem\utils\peer_registry.py"
+    if (-not (Test-Path $helper)) { return @() }
+    try {
+        $out = & python3 $helper claimed-ports 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $out) {
+            $out = & python $helper claimed-ports 2>$null
+        }
+        if ($out) {
+            return ($out -split '\s+' | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ })
+        }
+    } catch {}
+    return @()
+}
+
+function Register-InPeers {
+    param([string]$BrainstemDir, [int]$Port)
+    $helper = Join-Path $BRAINSTEM_HOME "src\rapp_brainstem\utils\peer_registry.py"
+    if (-not (Test-Path $helper)) { return }
+    $version = ""
+    $vf = Join-Path $BrainstemDir "VERSION"
+    if (Test-Path $vf) { $version = (Get-Content $vf -Raw).Trim() }
+    try {
+        & python3 $helper upsert $BrainstemDir $Port $version 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            & python $helper upsert $BrainstemDir $Port $version 2>$null | Out-Null
+        }
+    } catch {}
+}
+
 function Find-FreePort {
     param([int]$StartPort = 7072)
     $lim = $StartPort + 50
+    $claimed = @(Get-ClaimedPorts)
     for ($p = $StartPort; $p -lt $lim; $p++) {
         $inUse = $false
-        try {
-            $conn = Get-NetTCPConnection -LocalPort $p -ErrorAction SilentlyContinue
-            if ($conn) { $inUse = $true }
-        } catch {
-            # Fallback if Get-NetTCPConnection unavailable (older Windows)
+        if ($claimed -contains $p) { $inUse = $true }
+        if (-not $inUse) {
             try {
-                $tcp = New-Object System.Net.Sockets.TcpClient
-                $iar = $tcp.BeginConnect("127.0.0.1", $p, $null, $null)
-                $iar.AsyncWaitHandle.WaitOne(100) | Out-Null
-                if ($tcp.Connected) { $inUse = $true }
-                $tcp.Close()
-            } catch {}
+                $conn = Get-NetTCPConnection -LocalPort $p -ErrorAction SilentlyContinue
+                if ($conn) { $inUse = $true }
+            } catch {
+                # Fallback if Get-NetTCPConnection unavailable (older Windows)
+                try {
+                    $tcp = New-Object System.Net.Sockets.TcpClient
+                    $iar = $tcp.BeginConnect("127.0.0.1", $p, $null, $null)
+                    $iar.AsyncWaitHandle.WaitOne(100) | Out-Null
+                    if ($tcp.Connected) { $inUse = $true }
+                    $tcp.Close()
+                } catch {}
+            }
         }
         if (-not $inUse) { return $p }
     }
@@ -936,6 +972,7 @@ function Main-Local {
     $port = Find-FreePort -StartPort 7072
     Write-LocalLauncher -Port $port
     Update-ProjectGitignore
+    Register-InPeers -BrainstemDir (Join-Path $BRAINSTEM_HOME "src\rapp_brainstem") -Port $port
 
     $installedVersion = ""
     $vf = "$BRAINSTEM_HOME\src\rapp_brainstem\VERSION"
@@ -985,6 +1022,7 @@ function Main {
     Setup-Dependencies
     Install-CLI
     Create-Env
+    Register-InPeers -BrainstemDir (Join-Path $BRAINSTEM_HOME "src\rapp_brainstem") -Port 7071
 
     $installedVersion = ""
     $vf = "$BRAINSTEM_HOME\src\rapp_brainstem\VERSION"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1256,16 +1256,43 @@ with open(sys.argv[2], 'w') as f: json.dump(out, f)
 # ── Project-local helpers (--here mode) ──────────────────────────────
 
 find_free_port() {
+    # Pick a port free in three senses (good-neighbor pattern):
+    #   1. No process currently listening (lsof)
+    #   2. No TCP accept on 127.0.0.1 (covers ports without lsof permission)
+    #   3. Not claimed by another brainstem in the peer registry
+    #      (~/.config/rapp/peers.json — set by previous installs that
+    #      haven't started yet, so two back-to-back --here installs don't
+    #      both claim 7072 and crash on first start.)
     local start="${1:-7072}" p="$start" lim=$((start + 50))
+    local registry_helper="$BRAINSTEM_HOME/src/rapp_brainstem/utils/peer_registry.py"
+    local claimed=""
+    if [ -f "$registry_helper" ]; then
+        claimed=$(python3 "$registry_helper" claimed-ports 2>/dev/null || true)
+    fi
     while [ "$p" -lt "$lim" ]; do
         if ! lsof -ti ":$p" >/dev/null 2>&1 && \
-           ! (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null; then
+           ! (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null && \
+           ! echo " $claimed " | grep -q " $p "; then
             echo "$p"
             return 0
         fi
         p=$((p + 1))
     done
     echo "$start"
+}
+
+register_in_peers() {
+    # Append this install to the local peer registry so future installs
+    # see its port. The /api/peers endpoint reads the same file at runtime
+    # to render the neighborhood view.
+    local brainstem_dir="$1" port="$2"
+    local registry_helper="$BRAINSTEM_HOME/src/rapp_brainstem/utils/peer_registry.py"
+    local version=""
+    [ -f "$BRAINSTEM_HOME/src/rapp_brainstem/VERSION" ] && \
+        version=$(cat "$BRAINSTEM_HOME/src/rapp_brainstem/VERSION" | tr -d '[:space:]')
+    if [ -f "$registry_helper" ]; then
+        python3 "$registry_helper" upsert "$brainstem_dir" "$port" "$version" >/dev/null 2>&1 || true
+    fi
 }
 
 write_local_launcher() {
@@ -1278,8 +1305,31 @@ write_local_launcher() {
 HERE="\$(cd "\$(dirname "\$0")" && pwd)"
 SRC="\$HERE/src/rapp_brainstem"
 VENV_PYTHON="\$HERE/venv/bin/python"
+PORT_FILE="\$HERE/PORT"
+
+# Good-neighbor pattern: if the install-time port is already taken at
+# launch (e.g. another brainstem grabbed it first), autopick the next
+# free port and persist the new value back to BRAINSTEM_HOME/PORT and
+# the peer registry so siblings see the actual running port.
+desired_port="${port}"
+[ -f "\$PORT_FILE" ] && desired_port=\$(cat "\$PORT_FILE" | tr -d '[:space:]')
+final_port="\$desired_port"
+if lsof -ti ":\$desired_port" >/dev/null 2>&1; then
+    p=\$((desired_port + 1))
+    while [ "\$p" -lt \$((desired_port + 50)) ]; do
+        if ! lsof -ti ":\$p" >/dev/null 2>&1 && \\
+           ! (exec 3<>/dev/tcp/127.0.0.1/\$p) 2>/dev/null; then
+            final_port="\$p"; break
+        fi
+        p=\$((p + 1))
+    done
+    echo "▶ Port \$desired_port busy; using \$final_port instead"
+    echo "\$final_port" > "\$PORT_FILE"
+    REGHELPER="\$SRC/utils/peer_registry.py"
+    [ -f "\$REGHELPER" ] && python3 "\$REGHELPER" upsert "\$SRC" "\$final_port" "" >/dev/null 2>&1 || true
+fi
 cd "\$SRC"
-PORT=${port} exec "\$VENV_PYTHON" brainstem.py "\$@"
+PORT=\$final_port exec "\$VENV_PYTHON" brainstem.py "\$@"
 LAUNCHER
     chmod +x "$launcher"
     echo "$port" > "$BRAINSTEM_HOME/PORT"
@@ -1321,6 +1371,7 @@ main_local() {
     port=$(find_free_port 7072)
     write_local_launcher "$port"
     ensure_project_gitignore
+    register_in_peers "$BRAINSTEM_HOME/src/rapp_brainstem" "$port"
 
     local installed_version
     installed_version=$(cat "$BRAINSTEM_HOME/src/rapp_brainstem/VERSION" 2>/dev/null | tr -d '[:space:]')
@@ -1392,6 +1443,7 @@ main() {
     install_cli
     create_env
     install_binder_locally
+    register_in_peers "$BRAINSTEM_HOME/src/rapp_brainstem" 7071
 
     # Make sure brainstem and gh are on PATH for this session
     export PATH="$BRAINSTEM_BIN:/opt/homebrew/bin:/usr/local/bin:$PATH"

--- a/rapp_brainstem/brainstem.py
+++ b/rapp_brainstem/brainstem.py
@@ -1799,6 +1799,79 @@ def health():
             "agents": list(agents.keys()),
         })
 
+@app.route("/api/peers", methods=["GET"])
+def api_peers():
+    """Brainstem-neighborhood view of every install on this machine.
+
+    Reads the shared peer registry (~/.config/rapp/peers.json — written by
+    the installer) and probes each entry's /health endpoint with a short
+    timeout to mark it live or offline. The current brainstem flags itself
+    via the `is_self` field so the UI can highlight it.
+
+    Time-travel safe like the rest of the wire: the response shape is
+    additive-only and missing fields degrade silently.
+    """
+    import urllib.request as _urlreq
+    import urllib.error as _urlerr
+    try:
+        from utils import peer_registry
+    except Exception as e:
+        return jsonify({"peers": [], "error": f"peer_registry unavailable: {e}"}), 200
+
+    self_dir = os.path.dirname(os.path.abspath(__file__))
+    self_id = peer_registry._peer_id(self_dir)
+
+    data = peer_registry.load()
+    peers_out = []
+    for p in data.get("peers", []):
+        port = int(p.get("port") or 0)
+        live = False
+        live_version = None
+        if port:
+            try:
+                req = _urlreq.Request(f"http://127.0.0.1:{port}/health", headers={"User-Agent": "rapp-peers"})
+                with _urlreq.urlopen(req, timeout=1.0) as r:
+                    body = r.read().decode("utf-8", errors="replace")
+                    try:
+                        h = json.loads(body)
+                        live = True
+                        live_version = h.get("version")
+                    except Exception:
+                        live = r.status == 200
+            except (_urlerr.URLError, OSError, TimeoutError):
+                live = False
+
+        peers_out.append({
+            "id":            p.get("id"),
+            "brainstem_dir": p.get("brainstem_dir"),
+            "port":          port,
+            "is_global":     bool(p.get("is_global")),
+            "project_name":  p.get("project_name") or "",
+            "version":       live_version or p.get("version") or "",
+            "installed_at":  p.get("installed_at") or "",
+            "live":          live,
+            "is_self":       p.get("id") == self_id,
+        })
+    # Sort: self first, then global, then alphabetical by project_name
+    peers_out.sort(key=lambda x: (not x["is_self"], not x["is_global"], x["project_name"].lower()))
+    return jsonify({
+        "schema": "rapp-peers-view/1.0",
+        "self_id": self_id,
+        "self_brainstem_dir": self_dir,
+        "peers": peers_out,
+    })
+
+
+@app.route("/neighborhood", methods=["GET"])
+@app.route("/neighborhood.html", methods=["GET"])
+def neighborhood_page():
+    """Serve the neighborhood HTML viewer."""
+    return send_from_directory(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "utils", "web"),
+        "neighborhood.html",
+    )
+
+
 @app.route("/debug/auth", methods=["GET"])
 def debug_auth():
     """Debug endpoint — shows current auth state and tests token exchange."""

--- a/rapp_brainstem/utils/peer_registry.py
+++ b/rapp_brainstem/utils/peer_registry.py
@@ -1,0 +1,153 @@
+"""
+peer_registry.py — shared local-machine registry of installed brainstems.
+
+A "good neighbor" pattern for multi-brainstem hosts: each install records
+its claimed port + brainstem dir at a shared XDG path so subsequent
+installs can pick non-conflicting ports, and a running brainstem can
+discover its peers without a tree search.
+
+Registry schema (forever-additive, like the /chat envelope):
+    {
+      "schema": "rapp-peers/1.0",
+      "peers": [
+        {
+          "id":             "<sha256(brainstem_dir)[:12]>",
+          "brainstem_dir":  "/abs/path/to/.brainstem/src/rapp_brainstem",
+          "port":           7072,
+          "is_global":      false,
+          "project_name":   "my-project",
+          "installed_at":   "2026-04-26T20:30:00Z",
+          "version":        "0.12.2"
+        }, ...
+      ]
+    }
+
+The registry is intentionally a passive ledger — entries are appended on
+install and read on lookup. Liveness is determined by probing /health, not
+by entries getting "registered" and "unregistered" at runtime. This keeps
+the data model simple and survives ungraceful brainstem shutdowns.
+"""
+
+import hashlib
+import json
+import os
+import time
+from typing import Optional
+
+
+SCHEMA = "rapp-peers/1.0"
+
+
+def registry_path() -> str:
+    """XDG-style registry path: $XDG_CONFIG_HOME/rapp/peers.json or ~/.config/rapp/peers.json."""
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    return os.path.join(base, "rapp", "peers.json")
+
+
+def _peer_id(brainstem_dir: str) -> str:
+    return hashlib.sha256(os.path.abspath(brainstem_dir).encode()).hexdigest()[:12]
+
+
+def _project_name(brainstem_dir: str) -> str:
+    """Best-effort project label from the path. /Users/x/proj/.brainstem/src/rapp_brainstem → 'proj'.
+    The global install at $HOME/.brainstem/... is labeled 'global' instead of $USER."""
+    if _is_global(brainstem_dir):
+        return "global"
+    parts = os.path.abspath(brainstem_dir).split(os.sep)
+    try:
+        bs_idx = parts.index(".brainstem")
+        return parts[bs_idx - 1] if bs_idx > 0 else "global"
+    except ValueError:
+        return os.path.basename(os.path.dirname(brainstem_dir)) or "unknown"
+
+
+def _is_global(brainstem_dir: str) -> bool:
+    """Global install lives directly under $HOME/.brainstem (not project-local)."""
+    home = os.path.expanduser("~")
+    return os.path.abspath(brainstem_dir).startswith(os.path.join(home, ".brainstem", ""))
+
+
+def load() -> dict:
+    """Read the registry. Returns the empty registry if missing or unparseable."""
+    path = registry_path()
+    if not os.path.exists(path):
+        return {"schema": SCHEMA, "peers": []}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "peers" not in data:
+            return {"schema": SCHEMA, "peers": []}
+        data.setdefault("schema", SCHEMA)
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"schema": SCHEMA, "peers": []}
+
+
+def _save(data: dict) -> None:
+    path = registry_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, path)
+
+
+def upsert(brainstem_dir: str, port: int, version: Optional[str] = None) -> dict:
+    """Add or update a peer entry. Idempotent — repeat installs at the same dir overwrite cleanly."""
+    abs_dir = os.path.abspath(brainstem_dir)
+    pid = _peer_id(abs_dir)
+    entry = {
+        "id": pid,
+        "brainstem_dir": abs_dir,
+        "port": int(port),
+        "is_global": _is_global(abs_dir),
+        "project_name": _project_name(abs_dir),
+        "installed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "version": version or "",
+    }
+    data = load()
+    data["peers"] = [p for p in data["peers"] if p.get("id") != pid]
+    data["peers"].append(entry)
+    _save(data)
+    return entry
+
+
+def forget(brainstem_dir: str) -> bool:
+    """Remove a peer entry. Returns True if anything was removed."""
+    pid = _peer_id(brainstem_dir)
+    data = load()
+    before = len(data["peers"])
+    data["peers"] = [p for p in data["peers"] if p.get("id") != pid]
+    removed = len(data["peers"]) != before
+    if removed:
+        _save(data)
+    return removed
+
+
+def claimed_ports() -> set:
+    """Set of ports currently claimed by registered peers — for find_free_port to avoid."""
+    data = load()
+    return {int(p["port"]) for p in data["peers"] if isinstance(p.get("port"), int)}
+
+
+if __name__ == "__main__":
+    # CLI shim so install.sh can shell out for upsert/claimed-ports without
+    # rewriting the logic in bash. Usage:
+    #   python3 peer_registry.py claimed-ports
+    #   python3 peer_registry.py upsert <brainstem_dir> <port> [version]
+    #   python3 peer_registry.py forget <brainstem_dir>
+    #   python3 peer_registry.py list
+    import sys
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if cmd == "claimed-ports":
+        print(" ".join(str(p) for p in sorted(claimed_ports())))
+    elif cmd == "upsert":
+        e = upsert(sys.argv[2], int(sys.argv[3]), sys.argv[4] if len(sys.argv) > 4 else None)
+        print(json.dumps(e))
+    elif cmd == "forget":
+        print("removed" if forget(sys.argv[2]) else "not-found")
+    elif cmd == "list":
+        print(json.dumps(load(), indent=2))
+    else:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        sys.exit(2)

--- a/rapp_brainstem/utils/web/neighborhood.html
+++ b/rapp_brainstem/utils/web/neighborhood.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Brainstem Neighborhood</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --panel-hover: #1c232c;
+    --border: #2a3140;
+    --text: #e6edf3;
+    --muted: #8d96a0;
+    --green: #3fb950;
+    --gray: #5a6470;
+    --blue: #58a6ff;
+    --gold: #d29922;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    min-height: 100vh;
+  }
+  header {
+    padding: 24px 32px 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  header h1 {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 600;
+  }
+  header h1 .sub {
+    display: block;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--muted);
+    margin-top: 4px;
+  }
+  .controls {
+    margin-top: 16px;
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    font-size: 13px;
+    color: var(--muted);
+  }
+  .controls a {
+    color: var(--blue);
+    text-decoration: none;
+  }
+  .controls a:hover { text-decoration: underline; }
+  .legend {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .dot {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+  }
+  .dot.online  { background: var(--green); box-shadow: 0 0 6px rgba(63, 185, 80, 0.6); }
+  .dot.offline { background: var(--gray); }
+  main {
+    padding: 24px 32px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+  }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    transition: background 0.15s;
+  }
+  .card:hover { background: var(--panel-hover); }
+  .card.self { border-color: var(--blue); }
+  .card.global { border-left: 3px solid var(--gold); }
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 8px;
+  }
+  .card-title {
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 10px;
+    background: var(--blue);
+    color: var(--bg);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .badge.global { background: var(--gold); color: var(--bg); }
+  .card-meta {
+    color: var(--muted);
+    font-size: 12px;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    word-break: break-all;
+    margin-bottom: 12px;
+  }
+  .card-status {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+  .card-status .state {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+  }
+  .card-actions a {
+    color: var(--blue);
+    text-decoration: none;
+    font-size: 12px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    margin-left: 4px;
+  }
+  .card-actions a:hover { background: var(--panel-hover); }
+  .start-hint {
+    margin-top: 8px;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted);
+    background: rgba(0,0,0,0.3);
+    padding: 6px 8px;
+    border-radius: 4px;
+    word-break: break-all;
+  }
+  .empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 64px 32px;
+    color: var(--muted);
+    font-size: 14px;
+  }
+  .empty code {
+    background: var(--panel);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+  .meta-row {
+    color: var(--muted);
+    font-size: 11px;
+    display: flex;
+    gap: 12px;
+    margin-top: 4px;
+  }
+  .refresh {
+    color: var(--muted);
+    font-size: 11px;
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>
+    Brainstem Neighborhood
+    <span class="sub">every RAPP brainstem this machine knows about — online and off</span>
+  </h1>
+  <div class="controls">
+    <span class="legend"><span class="dot online"></span> online</span>
+    <span class="legend"><span class="dot offline"></span> offline</span>
+    <span class="refresh" id="refresh">Refreshing every 5s · last update: never</span>
+    <a href="/">← chat</a>
+  </div>
+</header>
+
+<main id="grid">
+  <div class="empty">Loading neighborhood…</div>
+</main>
+
+<script>
+const grid = document.getElementById('grid');
+const refresh = document.getElementById('refresh');
+
+function timeAgo(iso) {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (!t) return '';
+  const s = Math.floor((Date.now() - t) / 1000);
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s/60)}m ago`;
+  if (s < 86400) return `${Math.floor(s/3600)}h ago`;
+  return `${Math.floor(s/86400)}d ago`;
+}
+
+function escapeHtml(s) {
+  return String(s || '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+function startCommand(p) {
+  // brainstem_dir is .../something/.brainstem/src/rapp_brainstem
+  // start.sh lives at .../something/.brainstem/start.sh
+  const dir = p.brainstem_dir || '';
+  const m = dir.match(/^(.*\/\.brainstem)\/src\/rapp_brainstem$/);
+  if (m) return `${m[1]}/start.sh`;
+  if (p.is_global) return `brainstem start`;
+  return dir;
+}
+
+function render(payload) {
+  const peers = payload.peers || [];
+  if (!peers.length) {
+    grid.innerHTML = `
+      <div class="empty">
+        No brainstems registered yet.<br>
+        Run <code>curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash</code>
+        to install one — or <code>... | bash -s -- --here</code> for a project-local one.
+      </div>`;
+    return;
+  }
+
+  grid.innerHTML = peers.map(p => {
+    const cls = ['card'];
+    if (p.is_self)   cls.push('self');
+    if (p.is_global) cls.push('global');
+    const dotCls = p.live ? 'online' : 'offline';
+    const stateLabel = p.live ? 'online' : 'offline';
+    const versionStr = p.version ? `v${escapeHtml(p.version)}` : '';
+    const uiUrl = p.live ? `http://127.0.0.1:${p.port}/` : null;
+    const installedRel = p.installed_at ? `installed ${escapeHtml(timeAgo(p.installed_at))}` : '';
+
+    const title = p.is_global ? 'Global' : escapeHtml(p.project_name || `peer-${p.id}`);
+    const badge = p.is_self
+      ? `<span class="badge">this brainstem</span>`
+      : (p.is_global ? `<span class="badge global">global</span>` : '');
+
+    return `
+      <div class="${cls.join(' ')}">
+        <div class="card-header">
+          <span class="card-title">${title}</span>
+          ${badge}
+        </div>
+        <div class="card-meta">${escapeHtml(p.brainstem_dir)}</div>
+        <div class="meta-row">
+          <span>port ${p.port}</span>
+          ${versionStr ? `<span>${versionStr}</span>` : ''}
+          ${installedRel ? `<span>${installedRel}</span>` : ''}
+        </div>
+        <div class="card-status">
+          <span class="state">
+            <span class="dot ${dotCls}"></span>${stateLabel}
+          </span>
+          <span class="card-actions">
+            ${uiUrl ? `<a href="${uiUrl}" target="_blank">open ↗</a>` : ''}
+          </span>
+        </div>
+        ${!p.live && !p.is_self ? `<div class="start-hint">${escapeHtml(startCommand(p))}</div>` : ''}
+      </div>
+    `;
+  }).join('');
+}
+
+async function poll() {
+  try {
+    const r = await fetch('/api/peers', { cache: 'no-store' });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const data = await r.json();
+    render(data);
+    refresh.textContent = `Refreshing every 5s · last update: ${new Date().toLocaleTimeString()}`;
+  } catch (e) {
+    refresh.textContent = `Refresh failed: ${e.message} (retrying)`;
+  }
+}
+
+poll();
+setInterval(poll, 5000);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Multiple brainstems on the same machine play nice now: install-time port-pick avoids ports already claimed by other installs (even ones not currently running), runtime port-pick recovers from collisions, and brainstems can discover each other via a new `/api/peers` endpoint feeding a `/neighborhood` HTML viewer.

## Changes

**`rapp_brainstem/utils/peer_registry.py`** (new) — XDG-style ledger at `~/.config/rapp/peers.json`, schema `rapp-peers/1.0`. Entry shape: `{id, brainstem_dir, port, is_global, project_name, installed_at, version}`. CLI shim (`claimed-ports` / `upsert` / `forget` / `list`) so installers can use it without rewriting the logic in bash/PowerShell.

**`installer/install.sh`** — `find_free_port` reads the registry; back-to-back project-local installs no longer both claim 7072. After success, both `main_global` (port 7071) and `main_local` register themselves. Generated `start.sh` (from `write_local_launcher`) test-binds at launch and autopicks if the configured port got grabbed by something else, writing the new value back to `BRAINSTEM_HOME/PORT` and the registry.

**`installer/install.ps1`** — same pattern: `Get-ClaimedPorts` reads the registry via `python3 ... peer_registry.py claimed-ports`; `Register-InPeers` upserts after install.

**`rapp_brainstem/brainstem.py`** — new `GET /api/peers` reads the registry, probes each entry's `/health` (1s timeout) to mark `live` / offline, sorts self-first then global then alphabetical by project_name. Self is flagged via `is_self`. New routes `/neighborhood` and `/neighborhood.html` serve the viewer.

**`rapp_brainstem/utils/web/neighborhood.html`** (new) — dark-mode grid, one card per brainstem. Auto-polls `/api/peers` every 5s. Self is bordered, global is gold-striped. Online cards link to `http://127.0.0.1:<port>/`; offline cards show a copy-paste start command.

## Test plan

- [x] Registry round-trips (`upsert` / `claimed-ports` / `forget` / `list`)
- [x] Two installs back-to-back claim distinct ports (registry-aware, even when neither is running)
- [x] Generated `start.sh` parses + has the autopick block; survives `bash -n`
- [x] `/api/peers` returns correct shape: pre-seeded fake peers show `live=false`, real brainstem shows `live=true, is_self=true`
- [x] `/neighborhood` returns HTTP 200 + valid HTML
- [x] Existing tests still pass: `node tests/run-tests.mjs` (72/72), `node tests/vault-check.mjs` (0 failures), `bash tests/e2e/08-html-pages.sh`
- [ ] **Manual test (user-side):** install in two project dirs, start both, open `/neighborhood` — verify both appear, second-installed has a different port from first

## Test guide for the user

```bash
# Project A — install + start
mkdir /tmp/test-A && cd /tmp/test-A
curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash -s -- --here
./.brainstem/start.sh &

# Project B — install + start (should pick a different port)
mkdir /tmp/test-B && cd /tmp/test-B
curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash -s -- --here
./.brainstem/start.sh &

# Open the neighborhood from either:
open http://localhost:7072/neighborhood   # or whatever port A is on
```

The neighborhood page should show: project A (online, port 7072), project B (online, different port, e.g. 7073), and the global brainstem (online or offline depending on whether it's running). Self is highlighted with a blue border, global with a gold left edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)