### PR TITLE
Installer page: collapse Tier 1 by default

### DIFF
--- a/installer/index.html
+++ b/installer/index.html
@@ -120,7 +120,7 @@
 
 <div class="tiers">
 
-  <div class="tier open" data-tier="1">
+  <div class="tier" data-tier="1">
     <div class="tier-head" onclick="this.parentNode.classList.toggle('open')">
       <span class="tier-icon">🧠</span>
       <div class="tier-title">


### PR DESCRIPTION
Hero shows the global one-liner front and center. Auto-expanding Tier 1 duplicated that command and pre-expanded four sub-steps (install / run / project-local / virtual brainstem) before new users had a chance to ask whether they wanted the detail.

All three tiers now collapse equally. New users see one command in the hero; anyone who wants more clicks the tier they care about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)