### PR TITLE
fix(ui): rapplications panel ReferenceError — state cross-script scope

### DIFF
--- a/rapp_brainstem/index.html
+++ b/rapp_brainstem/index.html
@@ -2548,7 +2548,17 @@ function escapeAttr(s) {
 // override the canonical structure.
 const SOUL = '[soul rendered dynamically — see buildSystemPrompt()]';
 
-const state = {
+// `var` (not `const`) so the binding lives on `window` and is reachable
+// from the earlier <script> block (lines ~1733–1978), where rappRow()
+// and exportRapp() read state.settings.tetherUrl. `const` at top level
+// of a <script> creates a script-scoped binding that's invisible to
+// other <script> tags — that's what was throwing
+//   ReferenceError: state is not defined
+// when the rapplications panel rendered. `var` at top level becomes a
+// window property and is reachable from any script tag in the page.
+// Nothing reassigns `state` itself anywhere — only its sub-properties
+// are mutated — so dropping `const` doesn't lose any safety.
+var state = {
   sessionId: crypto.randomUUID(),
   conversation_history: [],
   fullTranscript: [],

--- a/rapp_brainstem/utils/web/index.html
+++ b/rapp_brainstem/utils/web/index.html
@@ -2259,7 +2259,12 @@ function escapeAttr(s) {
 // override the canonical structure.
 const SOUL = '[soul rendered dynamically — see buildSystemPrompt()]';
 
-const state = {
+// `var` (not `const`) so the binding lives on `window` and is reachable
+// from the earlier <script> block where rappRow() reads state.settings.tetherUrl.
+// `const` at top level of a <script> creates a script-scoped binding
+// that's invisible to other <script> tags — see the matching note in
+// rapp_brainstem/index.html for the full reasoning.
+var state = {
   sessionId: crypto.randomUUID(),
   conversation_history: [],
   fullTranscript: [],


### PR DESCRIPTION
## Bug

Console showed:
```
Uncaught (in promise) ReferenceError: state is not defined
    at rappRow ((index):1796:28)
```

The catalog render crashed mid-loop, producing an empty `CATALOG (RAPPSTORE) (0)` even when the brainstem successfully fetched all 34 rapps from `kody-w/rapp_store/main/index.json`.

## Root cause

`rappRow()` and `exportRapp()` live in the earlier inline `<script>` block (~1733–1978) and read `state.settings.tetherUrl`. `state` itself was declared with `const` at the top of the later `<script>` block (~2241+). `const` at top level of a `<script>` creates a script-scoped binding that is **not exposed on `window`** — so the earlier script tag can't see it. ReferenceError on first render.

## Fix

`const state = { ... }` → `var state = { ... }` in both:
- `rapp_brainstem/index.html` (Flask UI, line 2551)
- `rapp_brainstem/utils/web/index.html` (browser-only mirror, line 2262)

`var` at top level becomes a `window` property and is reachable from any `<script>` tag in the page. Verified via grep that nothing reassigns `state` itself anywhere — only sub-properties are mutated — so dropping const-correctness here is a no-op safety-wise.

## Verification

- [x] Both `var state = {` declarations confirmed at expected lines
- [x] Headless `node --check` on all 7 inline `<script>` bodies across both files — all parse cleanly
- [x] `node tests/run-tests.mjs` (72/72)
- [x] `bash tests/e2e/08-html-pages.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)