### PR TITLE
brainstem chat UI: surface rapplications + store + RAR in welcome

### DIFF
--- a/rapp_brainstem/index.html
+++ b/rapp_brainstem/index.html
@@ -934,7 +934,8 @@
       <ul>
         <li><strong>Chat</strong>: Just ask me questions below to start building and researching!</li>
         <li><strong>Agents Panel</strong>: Click the <svg class="iconify" style="vertical-align: middle; width: 1.25em; height: 1.25em;" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v4h4v2h-4v4h-2v-4H7v-2h4z"/></svg> icon (top right) to view or remove installed tools.</li>
-        <li><strong>Add Skills</strong>: Drag and drop any <code>.py</code> agent file directly onto this window to instantly teach me new things.</li>
+        <li><strong>Rapplications</strong>: open the <a href="/binder" target="_blank">Binder</a> to browse and install bundled apps (agent + UI / service / state) from the public <a href="https://github.com/kody-w/RAPP_Store" target="_blank">RAPP store</a> — BookFactory, ExecBrief, Kanban, Dashboard, Webhook, and more.</li>
+        <li><strong>Add Skills</strong>: Drag and drop any <code>.py</code> agent file directly onto this window to instantly teach me new things. For bare single-file agents, browse the <a href="https://github.com/kody-w/RAR" target="_blank">RAR registry</a>.</li>
       </ul>
       <p><em>Click one of the prompts below to get started!</em></p>
     </div>
@@ -944,8 +945,8 @@
 <footer>
   <div id="starter-prompts">
     <button class="starter-btn" onclick="useStarter('What exactly can you do?')">What can you do?</button>
+    <button class="starter-btn" onclick="useStarter('What rapplications are available in the public store, and which one should I install first?')">Browse the rapp store</button>
     <button class="starter-btn" onclick="useStarter('Help me build a new tool.')">Help me build a new tool</button>
-    <button class="starter-btn" onclick="useStarter('How do I manage my agent files?')">How do I manage agents?</button>
   </div>
   <div class="toolbar-row">
     <div class="left">
@@ -2363,7 +2364,8 @@
           <ul>
             <li><strong>Chat</strong>: Just ask me questions below to start building and researching!</li>
             <li><strong>Agents Panel</strong>: Click the <svg class="iconify" style="vertical-align: middle; width: 1.25em; height: 1.25em;" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v4h4v2h-4v4h-2v-4H7v-2h4z"/></svg> icon (top right) to view or remove installed tools.</li>
-            <li><strong>Add Skills</strong>: Drag and drop any <code>.py</code> agent file directly onto this window to instantly teach me new things.</li>
+            <li><strong>Rapplications</strong>: open the <a href="/binder" target="_blank">Binder</a> to browse and install bundled apps from the public <a href="https://github.com/kody-w/RAPP_Store" target="_blank">RAPP store</a>.</li>
+            <li><strong>Add Skills</strong>: Drag and drop any <code>.py</code> agent file directly onto this window — for the registry of bare single-file agents, see <a href="https://github.com/kody-w/RAR" target="_blank">RAR</a>.</li>
           </ul>
           <p><em>Click one of the prompts below to get started!</em></p>
         </div>


### PR DESCRIPTION
The localhost:7071/ welcome (chat UI's quick tour) didn't mention rapplications, the public store, or RAR — new users couldn't see the broader ecosystem from the front door.

## What changes

- **Welcome tour** gains a 4th bullet: \`Rapplications: open the Binder to browse and install bundled apps from the public RAPP store\` (links to /binder + github.com/kody-w/RAPP_Store).
- **Add Skills** bullet picks up a sub-reference to RAR for bare single-file agents per Constitution Article XXVII.
- **Quick-prompt buttons**: replaced \`How do I manage agents?\` with \`Browse the rapp store\` — the new prompt actually demos the rapplication path the welcome just introduced.
- Both copies of the welcome (initial render + clear-chat re-render at line 2362) updated in lockstep.

## Cross-repo links policy

Welcome links go to **source repos** (\`github.com/kody-w/RAPP_Store\`, \`github.com/kody-w/RAR\`), not other repos' hosted UI. RAPP's UI references rapp_store/RAR data, not their pages.

## Test plan

- [ ] Visit \`http://localhost:7071/\` after pulling latest
- [ ] Welcome screen shows 4 bullets including the new \"Rapplications\" item linking to /binder
- [ ] Quick-prompt row shows \`What can you do?\` · \`Browse the rapp store\` · \`Help me build a new tool\`
- [ ] Click the new prompt → message *\"What rapplications are available in the public store, and which one should I install first?\"* sends to /chat. The brainstem currently lacks a binder agent (filed as #22), so the response will be the model speculating; that's expected until #22 lands.
- [ ] Clear chat (Clear button in toolbar) → re-rendered welcome includes the same 4 bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)