### PR TITLE
Step F (Proposal 0002): three-source binder + chat-callable binder_agent (closes #22)

### DIFF
--- a/rapp_brainstem/agents/binder_agent.py
+++ b/rapp_brainstem/agents/binder_agent.py
@@ -1,0 +1,178 @@
+"""binder_agent.py — chat-callable surface for the binder package manager.
+
+Kernel-baked alongside binder_service.py per Article XXVII.4 (this is a
+bare agent that ships with the brainstem because it's the bootstrap
+loader for everything else — it can't be installed via the catalog
+because it IS the installer). Closes kody-w/RAPP#22.
+
+Talks to all three stores in the RAPP ecosystem (Article XXVII / XXXI):
+
+    rapplications  → kody-w/RAPP_Store
+    bare agents    → kody-w/RAR
+    senses         → kody-w/RAPP_Sense_Store
+
+Delegates to binder_service.handle() in-process — no HTTP loopback,
+keeps Tier 1 lean.
+"""
+from __future__ import annotations
+
+import json
+
+from agents.basic_agent import BasicAgent
+
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@rapp/binder",
+    "display_name": "Binder",
+    "version": "1.1.0",
+    "description": (
+        "Browse and install RAPP artifacts from the three peer stores: "
+        "rapplications (kody-w/RAPP_Store), bare agents (kody-w/RAR), and "
+        "senses (kody-w/RAPP_Sense_Store). Use this whenever the user "
+        "wants to install, remove, or browse anything that lives in those "
+        "stores."
+    ),
+    "author": "RAPP",
+    "tags": ["package-manager", "store", "platform", "kernel-baked"],
+    "category": "platform",
+    "quality_tier": "official",
+    "requires_env": [],
+    "example_call": {"args": {"action": "browse"}},
+}
+
+
+class BinderAgent(BasicAgent):
+    def __init__(self):
+        self.name = "Binder"
+        self.metadata = {
+            "name": "binder",
+            "description": (
+                "Package manager for the RAPP three-store ecosystem. Browse "
+                "or install rapplications (bundled apps with UI / service / "
+                "eggs), bare agents (single-file *_agent.py), or senses "
+                "(per-channel output overlays). Calls the local "
+                "binder_service in-process — no HTTP roundtrip. Use this "
+                "whenever the user wants to add, remove, or discover any "
+                "RAPP artifact."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "list",
+                            "browse",
+                            "browse_agents",
+                            "browse_senses",
+                            "browse_all",
+                            "install",
+                            "install_agent",
+                            "install_sense",
+                            "uninstall",
+                            "uninstall_agent",
+                            "uninstall_sense",
+                        ],
+                        "description": (
+                            "list                — what's installed (all kinds)\n"
+                            "browse              — rapplication catalog\n"
+                            "browse_agents       — bare-agent registry (RAR)\n"
+                            "browse_senses       — sense catalog\n"
+                            "browse_all          — aggregated three-store view\n"
+                            "install <id>        — rapplication by id\n"
+                            "install_agent <name>— bare agent by '@publisher/slug'\n"
+                            "install_sense <name>— sense by slug\n"
+                            "uninstall* — the matching reverse"
+                        ),
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Rapplication id (for install / uninstall).",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": (
+                            "Agent name '@publisher/slug' (for install_agent / "
+                            "uninstall_agent) or sense name (for install_sense / "
+                            "uninstall_sense)."
+                        ),
+                    },
+                },
+                "required": ["action"],
+            },
+        }
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        # Lazy import so the brainstem can load binder_agent before the
+        # services dir is even on sys.path. binder_service is kernel-baked
+        # in utils/services/, sibling to this file.
+        try:
+            from utils.services.binder_service import handle
+        except ImportError:
+            try:
+                # Path fallback if imports are mounted differently in
+                # alternate brainstem layouts (Tier 2/3, openrappter).
+                import importlib, sys, os
+                sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+                from utils.services.binder_service import handle
+            except Exception as e:
+                return json.dumps({"error": f"binder_service unavailable: {e}"})
+
+        action = kwargs.get("action")
+        rid = kwargs.get("id", "")
+        name = kwargs.get("name", "")
+
+        # Map action → (HTTP method, path, body)
+        if action == "list":
+            method, path, body = "GET", "", None
+        elif action == "browse":
+            method, path, body = "GET", "catalog", None
+        elif action == "browse_agents":
+            method, path, body = "GET", "catalog/agents", None
+        elif action == "browse_senses":
+            method, path, body = "GET", "catalog/senses", None
+        elif action == "browse_all":
+            method, path, body = "GET", "catalog/all", None
+        elif action == "install":
+            if not rid:
+                return json.dumps({"error": "id required for action=install"})
+            method, path, body = "POST", "install", {"id": rid}
+        elif action == "install_agent":
+            if not name:
+                return json.dumps({"error": "name required (e.g. '@rapp/learn_new')"})
+            method, path, body = "POST", "install/agent", {"name": name}
+        elif action == "install_sense":
+            if not name:
+                return json.dumps({"error": "name required (sense slug)"})
+            method, path, body = "POST", "install/sense", {"name": name}
+        elif action == "uninstall":
+            if not rid:
+                return json.dumps({"error": "id required for action=uninstall"})
+            method, path, body = "DELETE", f"installed/{rid}", None
+        elif action == "uninstall_agent":
+            if not name:
+                return json.dumps({"error": "name required"})
+            method, path, body = "DELETE", f"installed/agent/{name}", None
+        elif action == "uninstall_sense":
+            if not name:
+                return json.dumps({"error": "name required"})
+            method, path, body = "DELETE", f"installed/sense/{name}", None
+        else:
+            return json.dumps({"error": f"unknown action: {action}"})
+
+        try:
+            result = handle(method, path, body)
+        except Exception as e:
+            return json.dumps({"error": f"binder_service.handle failed: {e}"})
+
+        # binder_service returns either (body, status) or (body, status, headers)
+        if isinstance(result, tuple):
+            payload = result[0]
+        else:
+            payload = result
+
+        if isinstance(payload, (dict, list)):
+            return json.dumps(payload, default=str)
+        return str(payload)

--- a/rapp_brainstem/utils/services/binder_service.py
+++ b/rapp_brainstem/utils/services/binder_service.py
@@ -2,17 +2,31 @@
 binder_service.py — package manager for a brainstem (kernel-baked).
 
 Lives in rapp_brainstem/utils/services/ so it ships with the brainstem
-itself — no rapp-store install step needed. The catalog itself lives in
-the separate kody-w/rapp_store repo (split out of kody-w/RAPP on
-2026-04-26); this service fetches index.json from there via RAPPSTORE_URL.
+itself — no rapp-store install step needed. Talks to all three peer
+stores in the RAPP ecosystem (Constitution Article XXVII / XXXI; Proposal
+0002 in kody-w/RAPP_Store):
+
+    rapplications  → kody-w/RAPP_Store   (RAPPSTORE_URL)
+    bare agents    → kody-w/RAR          (RAR_URL)
+    senses         → kody-w/RAPP_Sense_Store (SENSESTORE_URL)
 
 Endpoints:
-    GET    /api/binder                    — list installed rapplications
-    GET    /api/binder/catalog            — fetch remote catalog
-    POST   /api/binder/install            — install by id (body: {"id": "...", "version"?})
-    DELETE /api/binder/installed/<id>     — uninstall by id
-    GET    /api/binder/export/<id>        — export installed rapp as a .egg cartridge
-    POST   /api/binder/import             — import a .egg cartridge (body: {"egg_b64": "..."})
+    GET    /api/binder                       — list installed (all kinds)
+    GET    /api/binder/catalog               — rapplications catalog
+    GET    /api/binder/catalog/agents        — bare agents (RAR)
+    GET    /api/binder/catalog/senses        — senses
+    GET    /api/binder/catalog/all           — aggregated three-store view
+    POST   /api/binder/install               — install rapplication by id
+                                                (body: {"id": "...", "version"?})
+    POST   /api/binder/install/agent         — install bare agent from RAR
+                                                (body: {"name": "@pub/slug"})
+    POST   /api/binder/install/sense         — install sense
+                                                (body: {"name": "<slug>"} or "@pub/<slug>")
+    DELETE /api/binder/installed/<id>        — uninstall rapplication by id
+    DELETE /api/binder/installed/agent/<name> — uninstall bare agent
+    DELETE /api/binder/installed/sense/<name> — uninstall sense
+    GET    /api/binder/export/<id>           — export rapp as .egg cartridge
+    POST   /api/binder/import                — import a .egg cartridge
 
 Egg format (zip):
     manifest.json   {schema, type:"rapplication", id, version, exported_at,
@@ -52,6 +66,17 @@ _UI_BASE_DIR = os.path.join(_DATA_DIR, "rapp_ui")
 # catalog. A "RAPP Ubuntu" or "RAPP Arch" fork sets this to its own mirror
 # and binder transparently installs from there. Sacred wire stays the same.
 _CATALOG_URL = os.getenv("RAPPSTORE_URL", "https://raw.githubusercontent.com/kody-w/rapp_store/main/index.json")
+# The other two peer stores in the three-store ecosystem (Proposal 0002 in
+# kody-w/RAPP_Store, Constitution Article XXVII/XXXI). The binder talks to
+# all three via separate endpoints so chat can browse / install any of:
+#   - bundles (rapplications) → kody-w/RAPP_Store, RAPPSTORE_URL above
+#   - bare agents             → kody-w/RAR, RAR_URL
+#   - senses                  → kody-w/RAPP_Sense_Store, SENSESTORE_URL
+_RAR_URL = os.getenv("RAR_URL", "https://raw.githubusercontent.com/kody-w/RAR/main/registry.json")
+_SENSESTORE_URL = os.getenv("SENSESTORE_URL", "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/index.json")
+# Senses install into rapp_brainstem/utils/senses/ (Article XXIV — the
+# brainstem auto-discovers *_sense.py at startup).
+_SENSES_DIR = os.path.join(_BASE_DIR, "utils", "senses")
 
 
 def _read():
@@ -277,16 +302,178 @@ def _import_egg(body):
     return {"status": "ok", "id": rapp_id, "files_restored": files_restored, "installed": installed}, 200
 
 
+# ── Three-store catalog helpers (Proposal 0002) ─────────────────────────
+
+def _fetch_rar():
+    """Fetch the bare-agent registry from kody-w/RAR (or RAR_URL override)."""
+    try:
+        import requests
+        r = requests.get(_RAR_URL, timeout=10)
+        if r.status_code == 200:
+            d = r.json()
+            # Trim each entry so the chat surface sees the useful fields.
+            agents = [{
+                "name": a.get("name"),
+                "display_name": a.get("display_name") or a.get("name"),
+                "version": a.get("version"),
+                "description": (a.get("description") or "")[:240],
+                "tags": a.get("tags", []),
+                "category": a.get("category"),
+                "publisher": a.get("name", "").split("/")[0] if "/" in a.get("name", "") else None,
+            } for a in d.get("agents", [])]
+            return {"agents": agents}
+    except Exception:
+        pass
+    return {"agents": []}
+
+
+def _fetch_sensestore():
+    """Fetch the sense store catalog from kody-w/RAPP_Sense_Store."""
+    try:
+        import requests
+        r = requests.get(_SENSESTORE_URL, timeout=10)
+        if r.status_code == 200:
+            return r.json()
+    except Exception:
+        pass
+    return {"senses": []}
+
+
+def _install_agent(name):
+    """Install a bare agent from RAR by '@publisher/slug'. Writes to
+    <root>/agents/<slug>_agent.py and tracks in binder.json with kind=agent."""
+    if not name or "/" not in name:
+        return {"error": f"agent name must be '@publisher/slug', got {name!r}"}, 400
+    publisher, slug = name.split("/", 1)
+    if not slug.endswith("_agent"):
+        slug_full = slug + "_agent"
+    else:
+        slug_full = slug
+    raw_url = (
+        f"https://raw.githubusercontent.com/kody-w/RAR/main/agents/"
+        f"{publisher}/{slug_full}.py"
+    )
+    try:
+        content = _download(raw_url)
+    except Exception as e:
+        return {"error": f"agent download failed: {e}"}, 502
+    filename = f"{slug_full}.py"
+    _write_to_dir(_AGENTS_DIR, filename, content)
+    installed = {
+        "kind": "agent",
+        "id": name,
+        "version": "?",
+        "agent_filename": filename,
+        "filename": filename,
+        "source_repo": "kody-w/RAR",
+        "source_url": raw_url,
+    }
+    state = _read()
+    state["installed"] = [e for e in state.get("installed", []) if e.get("id") != name]
+    state["installed"].append(installed)
+    _write(state)
+    return {"status": "ok", "installed": installed}, 200
+
+
+def _install_sense(name):
+    """Install a sense from kody-w/RAPP_Sense_Store. The catalog entry's `url`
+    field is the canonical raw URL; we fetch it and drop into utils/senses/."""
+    cat = _fetch_sensestore()
+    entry = next((s for s in cat.get("senses", [])
+                  if s.get("name") == name or
+                     f"{s.get('publisher','')}/{s.get('name','')}" == name),
+                 None)
+    if not entry:
+        return {"error": f"sense '{name}' not found in catalog"}, 404
+    try:
+        content = _download(entry["url"], entry.get("sha256"))
+    except Exception as e:
+        return {"error": f"sense download failed: {e}"}, 502
+    filename = entry.get("filename") or f"{entry['name']}_sense.py"
+    _write_to_dir(_SENSES_DIR, filename, content)
+    installed = {
+        "kind": "sense",
+        "id": f"{entry.get('publisher', '@rapp')}/{entry['name']}",
+        "name": entry["name"],
+        "version": entry.get("version", "?"),
+        "delimiter": entry.get("delimiter"),
+        "surfaces": entry.get("surfaces", ["chat"]),
+        "filename": filename,
+        "source_repo": "kody-w/RAPP_Sense_Store",
+        "source_url": entry["url"],
+    }
+    state = _read()
+    state["installed"] = [e for e in state.get("installed", [])
+                          if not (e.get("kind") == "sense" and e.get("name") == entry["name"])]
+    state["installed"].append(installed)
+    _write(state)
+    return {"status": "ok", "installed": installed}, 200
+
+
+def _uninstall_agent_or_sense(kind, name):
+    """Uninstall a bare agent or sense by id. Different from rapplication
+    uninstall because there's no service / UI / state-cartridge to clean up."""
+    state = _read()
+    entry = next((e for e in state.get("installed", []) if
+                  (kind == "agent" and e.get("kind") == "agent" and e.get("id") == name) or
+                  (kind == "sense" and e.get("kind") == "sense" and
+                   (e.get("id") == name or e.get("name") == name))),
+                 None)
+    if not entry:
+        return {"error": f"not installed as {kind}: {name}"}, 404
+    if kind == "agent":
+        _remove_from_dir(_AGENTS_DIR, entry.get("filename") or entry.get("agent_filename"))
+    else:  # sense
+        _remove_from_dir(_SENSES_DIR, entry.get("filename"))
+    state["installed"] = [e for e in state.get("installed", []) if e is not entry]
+    _write(state)
+    return {"status": "ok", "uninstalled": name, "kind": kind}, 200
+
+
 # ── Dispatch ────────────────────────────────────────────────────────────
 
 def handle(method, path, body):
-    # GET /api/binder — list installed rapplications
+    # GET /api/binder — list installed rapplications + agents + senses
     if method == "GET" and path == "":
         return _read(), 200
 
-    # GET /api/binder/catalog — fetch remote catalog
+    # GET /api/binder/catalog — rapplications (kody-w/RAPP_Store)
     if method == "GET" and path == "catalog":
         return _fetch_catalog(), 200
+
+    # GET /api/binder/catalog/agents — bare agents (kody-w/RAR)
+    if method == "GET" and path == "catalog/agents":
+        return _fetch_rar(), 200
+
+    # GET /api/binder/catalog/senses — senses (kody-w/RAPP_Sense_Store)
+    if method == "GET" and path == "catalog/senses":
+        return _fetch_sensestore(), 200
+
+    # GET /api/binder/catalog/all — aggregated three-store view
+    if method == "GET" and path == "catalog/all":
+        return {
+            "rapplications": _fetch_catalog().get("rapplications", []),
+            "agents":        _fetch_rar().get("agents", []),
+            "senses":        _fetch_sensestore().get("senses", []),
+        }, 200
+
+    # POST /api/binder/install/agent — install bare agent from RAR
+    # body: {"name": "@publisher/slug"}
+    if method == "POST" and path == "install/agent":
+        return _install_agent((body or {}).get("name", ""))
+
+    # POST /api/binder/install/sense — install sense from RAPP_Sense_Store
+    # body: {"name": "<slug>"} or {"name": "@publisher/<slug>"}
+    if method == "POST" and path == "install/sense":
+        return _install_sense((body or {}).get("name", ""))
+
+    # DELETE /api/binder/installed/agent/<name>
+    if method == "DELETE" and path.startswith("installed/agent/"):
+        return _uninstall_agent_or_sense("agent", path[len("installed/agent/"):])
+
+    # DELETE /api/binder/installed/sense/<name>
+    if method == "DELETE" and path.startswith("installed/sense/"):
+        return _uninstall_agent_or_sense("sense", path[len("installed/sense/"):])
 
     # GET /api/binder/export/<id> — export installed rapp as a .egg cartridge
     if method == "GET" and path.startswith("export/"):


### PR DESCRIPTION
Closes #22 and implements step F of [kody-w/RAPP_Store#11 (Proposal 0002 — three-store ecosystem)](https://github.com/kody-w/RAPP_Store/blob/main/docs/proposals/0002-three-stores.md).

Two changes:

## 1. \`utils/services/binder_service.py\` — three sources

New env vars (with defaults pointing at the canonical raws):
- \`RAR_URL\` → \`kody-w/RAR/main/registry.json\`
- \`SENSESTORE_URL\` → \`kody-w/RAPP_Sense_Store/main/index.json\`

New endpoints:
- \`GET /api/binder/catalog/agents\` — bare-agent registry
- \`GET /api/binder/catalog/senses\` — sense catalog
- \`GET /api/binder/catalog/all\` — aggregated three-store view
- \`POST /api/binder/install/agent\` — install bare agent from RAR by \`@publisher/slug\`
- \`POST /api/binder/install/sense\` — install sense
- \`DELETE /api/binder/installed/agent/<name>\`
- \`DELETE /api/binder/installed/sense/<name>\`

Existing rapplication endpoints unchanged. Installed-record schema gains a \`kind\` field for unambiguous uninstall.

## 2. \`agents/binder_agent.py\` — NEW (closes #22)

Per Constitution Article XXVII.4 this is the kernel-baked exception: the binder agent is the bootstrap loader for everything else, so it can't be installed via the catalog (it IS the installer).

Chat-callable surface that maps actions → \`(method, path, body)\` and delegates to \`binder_service.handle()\` **in-process** — no HTTP loopback, keeps Tier 1 lean.

Actions: \`list\` · \`browse\` · \`browse_agents\` · \`browse_senses\` · \`browse_all\` · \`install\` · \`install_agent\` · \`install_sense\` · \`uninstall\` · \`uninstall_agent\` · \`uninstall_sense\`.

After this lands, users can say in chat: *"install learn_new"* / *"add the headline sense"* / *"browse the rapp store"* — and the LLM has a real tool for it.

## Test plan

- [ ] After pulling: \`brainstem\` starts and logs *"Agent loaded: Binder"* alongside the existing 6 default agents.
- [ ] \`curl http://localhost:7071/api/binder/catalog/all\` returns 7 rapplications + 267+ agents + 5 senses.
- [ ] \`curl -X POST http://localhost:7071/api/binder/install/sense -d '{"name":"eli5"}'\` writes \`utils/senses/eli5_sense.py\`. Restart picks it up.
- [ ] In chat: *"What rapplications are available?"* — model calls binder.browse(), returns the 7-entry catalog summary. Asks *"install kanban"* — model calls binder.install(id=kanban), agent + service files land in \`agents/\` + \`utils/services/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)