### PR TITLE
brainstem: per-rapp workspaces (SPEC §11)

### DIFF
--- a/rapp_brainstem/brainstem.py
+++ b/rapp_brainstem/brainstem.py
@@ -1817,6 +1817,13 @@ def agents_import():
         result = egg_mod.unpack(blob)
         if not result.get("ok"):
             return jsonify({"error": result.get("error", "egg unpack failed")}), 400
+        # SPEC §11 — ensure workspace exists for the just-unpacked rapp
+        try:
+            from utils import workspace as _ws
+            if result.get("id"):
+                _ws.ensure_workspace(result["id"])
+        except Exception:
+            pass
         # Reload agents so newly-restored ones become live for /chat
         try:
             load_agents()
@@ -1858,6 +1865,17 @@ def agents_import():
     filepath = os.path.join(AGENTS_PATH, safe_name)
     with open(filepath, 'wb') as out:
         out.write(blob)
+
+    # SPEC §11 — drop-installed .py agents also get a per-rapp workspace.
+    # Identity is derived from the filename root (matches how agent
+    # discovery and the binder identify rapps elsewhere).
+    try:
+        from utils import workspace as _ws
+        rapp_id_guess = safe_name[:-len("_agent.py")] if safe_name.endswith("_agent.py") else safe_name[:-3]
+        if rapp_id_guess:
+            _ws.ensure_workspace(rapp_id_guess)
+    except Exception:
+        pass
 
     try:
         load_agents()

--- a/rapp_brainstem/index.html
+++ b/rapp_brainstem/index.html
@@ -3165,11 +3165,20 @@
   //   { type: 'rapp:close' }                                  — closes the sender's tab
   //   { type: 'rapp:get_cartridge' }                          — request context (tether/user/etc.)
   //   { type: 'rapp:invoke', id: '...', args: {...} }         — call sender's agent.perform(**args)
+  //   { type: 'rapp:workspace:list', id }                     — list files in this rapp's workspace
+  //   { type: 'rapp:workspace:read', id, name }               — read a file
+  //   { type: 'rapp:workspace:write', id, name, content,
+  //                                   encoding }              — write a file (SPEC §11.3)
+  //   { type: 'rapp:workspace:delete', id, name }             — delete a file
+  //   { type: 'rapp:workspace:reveal', id }                   — open workspace folder in Finder
+  //   { type: 'rapp:workspace:request_files', id, prompt,
+  //                                   patterns }              — ask the user to drop files
   //
   // Parent → iframe responses:
   //   { type: 'rapp:cartridge', context: {...} }              — answer to get_cartridge
   //   { type: 'rapp:invoke:result', id, result }              — success (matches request id)
   //   { type: 'rapp:invoke:result', id, error }               — failure
+  //   { type: 'rapp:workspace:<verb>:result', id, ... }       — workspace op result
   //
   // The invoke path is what makes BookFactory and similar pipeline rapps
   // work: their iframe orchestrates the 5-persona pipeline and needs a
@@ -3200,15 +3209,99 @@
     } else if (data.type === 'rapp:get_cartridge') {
       // Reply with the iframe's context cartridge. We're the local
       // brainstem, so tether is "active" pointing at our own origin.
-      ev.source.postMessage({
-        type: 'rapp:cartridge',
-        rapp_id: senderId,
-        context: {
-          tether: { active: true, base: API || window.location.origin },
-          user:   null,  // GitHub identity not surfaced in this UI
-          env:    'local-brainstem',
-        },
-      }, '*');
+      // SPEC §11 — also probe the rapp's workspace so the iframe can
+      // render its file count / "open folder" affordance immediately.
+      const wsBase = (API || window.location.origin) + '/api/binder/workspace/' + encodeURIComponent(senderId);
+      fetch(wsBase + '/info').then(r => r.ok ? r.json() : null).catch(() => null).then(wsInfo => {
+        ev.source.postMessage({
+          type: 'rapp:cartridge',
+          rapp_id: senderId,
+          context: {
+            tether: { active: true, base: API || window.location.origin },
+            user:   null,  // GitHub identity not surfaced in this UI
+            env:    'local-brainstem',
+            workspace: wsInfo ? {
+              available: true,
+              path:      wsInfo.path,
+              mode:      wsInfo.mode || 'local',
+              file_count: wsInfo.file_count || 0,
+            } : { available: false, path: null, mode: 'local', file_count: 0 },
+          },
+        }, '*');
+      });
+    } else if (data.type && data.type.startsWith('rapp:workspace:')) {
+      // SPEC §11.3 — translate workspace messages into /api/binder/workspace
+      // calls. The bridge enforces that rapps can only touch their own
+      // sender-scoped workspace; senderId is whatever the iframe is, so
+      // even a malicious iframe can't reach into another rapp's dir.
+      const verb = data.type.slice('rapp:workspace:'.length);
+      const wsBase = (API || window.location.origin) + '/api/binder/workspace/' + encodeURIComponent(senderId);
+      const replyType = data.type + ':result';
+      const reply = (payload) => ev.source.postMessage({ type: replyType, id: data.id, ...payload }, '*');
+
+      const safeName = (n) => {
+        if (typeof n !== 'string' || !n) return null;
+        if (n.startsWith('/') || n.startsWith('\\')) return null;
+        if (n.split(/[\\/]/).includes('..')) return null;
+        return n;
+      };
+
+      if (verb === 'list') {
+        fetch(wsBase + '/list').then(r => r.json())
+          .then(d => reply({ files: d.files || [] }))
+          .catch(e => reply({ error: e.message }));
+      } else if (verb === 'read') {
+        const n = safeName(data.name);
+        if (!n) return reply({ error: 'invalid_name' });
+        fetch(wsBase + '/file/' + encodeURI(n))
+          .then(r => r.ok ? r.arrayBuffer().then(buf => ({ buf, type: r.headers.get('Content-Type') || '' }))
+                          : r.json().then(d => Promise.reject(new Error(d.error || ('HTTP ' + r.status)))))
+          .then(({ buf, type }) => {
+            // Text MIMEs → utf-8 string; everything else → base64
+            const isText = /^text\/|application\/json|charset=/.test(type);
+            if (isText) {
+              reply({ content: new TextDecoder().decode(buf), encoding: 'utf-8', mime: type });
+            } else {
+              const bytes = new Uint8Array(buf);
+              let bin = '';
+              for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+              reply({ content: btoa(bin), encoding: 'base64', mime: type });
+            }
+          })
+          .catch(e => reply({ error: e.message }));
+      } else if (verb === 'write') {
+        const n = safeName(data.name);
+        if (!n) return reply({ error: 'invalid_name' });
+        fetch(wsBase + '/file/' + encodeURI(n), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: data.content || '', encoding: data.encoding || 'utf-8' }),
+        })
+          .then(r => r.json().then(d => r.ok ? reply({ ok: true, name: d.name, size: d.size })
+                                              : reply({ error: d.error || ('HTTP ' + r.status) })))
+          .catch(e => reply({ error: e.message }));
+      } else if (verb === 'delete') {
+        const n = safeName(data.name);
+        if (!n) return reply({ error: 'invalid_name' });
+        fetch(wsBase + '/file/' + encodeURI(n), { method: 'DELETE' })
+          .then(r => r.json().then(d => r.ok ? reply({ ok: true })
+                                              : reply({ error: d.error || ('HTTP ' + r.status) })))
+          .catch(e => reply({ error: e.message }));
+      } else if (verb === 'reveal') {
+        fetch(wsBase + '/reveal', { method: 'POST' })
+          .then(r => r.json().then(d => r.ok ? reply({ ok: true, path: d.path })
+                                              : reply({ error: d.error || ('HTTP ' + r.status) })))
+          .catch(e => reply({ error: e.message }));
+      } else if (verb === 'request_files') {
+        // The chat UI doesn't yet render a request-files prompt to the user.
+        // Surface the prompt as a chat message so the user sees the ask;
+        // resolution is "cancelled" until a richer drawer ships.
+        const prompt = (data.prompt || 'wants you to drop files in its workspace').slice(0, 200);
+        appendMsg('assistant', `📎 **${senderId}** ${prompt}\n\nUse the **Open workspace folder** button in the rapp to drop files in.`);
+        reply({ cancelled: true });
+      } else {
+        reply({ error: 'unknown workspace verb: ' + verb });
+      }
     } else if (data.type === 'rapp:invoke') {
       // Direct invoke: look up the rapp's singleton_filename and call
       // /agents/invoke/<filename> with the iframe's args. Reply with the

--- a/rapp_brainstem/utils/services/binder_service.py
+++ b/rapp_brainstem/utils/services/binder_service.py
@@ -27,6 +27,12 @@ Endpoints:
     DELETE /api/binder/installed/sense/<name> — uninstall sense
     GET    /api/binder/export/<id>           — export rapp as .egg cartridge
     POST   /api/binder/import                — import a .egg cartridge
+    GET    /api/binder/workspace/<id>/info   — workspace path + file count (SPEC §11)
+    GET    /api/binder/workspace/<id>/list   — list files in the rapp's workspace
+    GET    /api/binder/workspace/<id>/file/<name>  — read file content
+    PUT    /api/binder/workspace/<id>/file/<name>  — write file (body: {content, encoding})
+    DELETE /api/binder/workspace/<id>/file/<name>  — delete file
+    POST   /api/binder/workspace/<id>/reveal — open the workspace folder in the OS file browser
 
 Egg format (zip):
     manifest.json   {schema, type:"rapplication", id, version, exported_at,
@@ -41,8 +47,12 @@ import hashlib
 import io
 import json
 import os
+import subprocess
+import sys
 import time
 import zipfile
+
+from utils import workspace as _ws
 
 name = "binder"
 
@@ -299,6 +309,8 @@ def _import_egg(body):
     state["installed"] = [e for e in state.get("installed", []) if e.get("id") != rapp_id]
     state["installed"].append(installed)
     _write(state)
+    # SPEC §11 — ensure workspace dir exists for the imported rapp
+    _ws.ensure_workspace(rapp_id)
     return {"status": "ok", "id": rapp_id, "files_restored": files_restored, "installed": installed}, 200
 
 
@@ -628,6 +640,9 @@ def handle(method, path, body):
         state["installed"] = [e for e in state["installed"] if e.get("id") != rapp_id]
         state["installed"].append(installed)
         _write(state)
+        # SPEC §11 — ensure the rapp's collaborative workspace exists. Idempotent;
+        # preserved on uninstall (it's user data, not engine data).
+        _ws.ensure_workspace(rapp_id)
         return {"status": "ok", "installed": installed}, 200
 
     # DELETE /api/binder/installed/<id> — uninstall a rapplication
@@ -660,6 +675,114 @@ def handle(method, path, body):
 
         state["installed"] = [e for e in state["installed"] if e.get("id") != rapp_id]
         _write(state)
+        # SPEC §11 — workspace dir is intentionally NOT removed on uninstall.
+        # It's user data; if the rapp gets reinstalled later the user's files
+        # are still there.
         return {"status": "ok", "uninstalled": rapp_id}, 200
+
+    # ── SPEC §11 — Per-rapp workspace endpoints ─────────────────────────
+    # These mirror the cartridge protocol's rapp:workspace:* messages over
+    # HTTP so the chat UI's postMessage bridge has somewhere to forward to.
+    # All ops are scoped to a single rapp's workspace dir; safe_workspace_path()
+    # rejects path traversal.
+    if path.startswith("workspace/"):
+        rest = path[len("workspace/"):]
+        # Split rapp_id off the front. Subroute can be "info", "list",
+        # "reveal", or "file/<name>" (name may contain slashes for subdirs).
+        parts = rest.split("/", 2)
+        if len(parts) < 2:
+            return {"error": "workspace route requires <id>/<subroute>"}, 400
+        rapp_id, sub = parts[0], parts[1]
+        tail = parts[2] if len(parts) > 2 else ""
+
+        # GET /api/binder/workspace/<id>/info
+        if method == "GET" and sub == "info":
+            ws = _ws.ensure_workspace(rapp_id)
+            if ws is None:
+                return {"error": "invalid rapp id"}, 400
+            files = _ws.list_workspace(rapp_id)
+            return {
+                "id": rapp_id,
+                "path": str(ws),
+                "exists": True,
+                "mode": "local",
+                "file_count": len(files),
+            }, 200
+
+        # GET /api/binder/workspace/<id>/list
+        if method == "GET" and sub == "list":
+            return {"files": _ws.list_workspace(rapp_id)}, 200
+
+        # GET /api/binder/workspace/<id>/file/<name>
+        # Returns the file content directly. ?encoding=base64 for binary.
+        if method == "GET" and sub == "file" and tail:
+            target = _ws.safe_workspace_path(rapp_id, tail)
+            if target is None:
+                return {"error": "invalid_name"}, 400
+            if not target.is_file():
+                return {"error": "not_found"}, 404
+            blob = target.read_bytes()
+            # The dispatcher's binary path: (bytes, status, headers).
+            ext = target.suffix.lower()
+            mime = {
+                ".txt": "text/plain; charset=utf-8",
+                ".md":  "text/markdown; charset=utf-8",
+                ".json": "application/json",
+                ".csv": "text/csv; charset=utf-8",
+                ".html": "text/html; charset=utf-8",
+                ".png": "image/png",
+                ".jpg": "image/jpeg",
+                ".jpeg": "image/jpeg",
+                ".pdf": "application/pdf",
+            }.get(ext, "application/octet-stream")
+            return blob, 200, {"Content-Type": mime, "Content-Length": str(len(blob))}
+
+        # PUT /api/binder/workspace/<id>/file/<name>
+        # body: {"content": "...", "encoding": "utf-8" | "base64"}
+        if method == "PUT" and sub == "file" and tail:
+            target = _ws.safe_workspace_path(rapp_id, tail)
+            if target is None:
+                return {"error": "invalid_name"}, 400
+            content = body.get("content", "")
+            encoding = body.get("encoding", "utf-8")
+            try:
+                if encoding == "base64":
+                    raw = base64.b64decode(content)
+                else:
+                    raw = str(content).encode("utf-8")
+            except Exception as e:
+                return {"error": f"invalid content: {e}"}, 400
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(raw)
+            return {"ok": True, "name": tail, "size": len(raw)}, 200
+
+        # DELETE /api/binder/workspace/<id>/file/<name>
+        if method == "DELETE" and sub == "file" and tail:
+            target = _ws.safe_workspace_path(rapp_id, tail)
+            if target is None:
+                return {"error": "invalid_name"}, 400
+            if target.is_file():
+                target.unlink()
+            return {"ok": True}, 200
+
+        # POST /api/binder/workspace/<id>/reveal — open in OS file browser.
+        # Local-brainstem only; the cartridge spec promises the host advertises
+        # mode=cloud and clients skip this call there.
+        if method == "POST" and sub == "reveal":
+            ws = _ws.ensure_workspace(rapp_id)
+            if ws is None:
+                return {"error": "invalid rapp id"}, 400
+            try:
+                if sys.platform == "darwin":
+                    subprocess.Popen(["open", str(ws)])
+                elif sys.platform.startswith("win"):
+                    os.startfile(str(ws))  # type: ignore[attr-defined]
+                else:
+                    subprocess.Popen(["xdg-open", str(ws)])
+            except Exception as e:
+                return {"error": f"could not reveal: {e}"}, 500
+            return {"ok": True, "path": str(ws)}, 200
+
+        return {"error": "workspace subroute not found"}, 404
 
     return {"error": "not found"}, 404

--- a/rapp_brainstem/utils/workspace.py
+++ b/rapp_brainstem/utils/workspace.py
@@ -1,0 +1,136 @@
+"""
+workspace.py — per-rapp file scratchpad helper.
+
+Implements SPEC §11 (kody-w/RAPP_Store). Every installed rapplication gets
+a persistent, isolated directory at ${BRAINSTEM_ROOT}/.brainstem_data/workspaces/<id>/
+where the user and the rapp can collaborate via files (CSVs, transcripts,
+generated outputs, anything that doesn't fit a perform() kwarg).
+
+Singletons access this via:
+
+    from utils.workspace import workspace_dir
+    ws = workspace_dir()   # pathlib.Path | None
+
+The helper walks the call stack to find the caller's __manifest__ and
+resolves the rapp id from it. Returns None outside a brainstem.
+
+The binder install hooks call ensure_workspace(<id>) directly to mkdir at
+install time; the HTTP service uses safe_workspace_path() for guarded
+file ops.
+
+Distinct from .brainstem_data/<id>/ (rapp-PRIVATE state, bundled into eggs
+as state/...). Workspaces are user-collaborative and intentionally NOT
+auto-bundled — large user files don't belong in shippable cartridges.
+"""
+
+import inspect
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+# rapp_brainstem/utils/workspace.py → walk three dirnames to brainstem root.
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_WORKSPACE_BASE = os.path.join(_BASE_DIR, ".brainstem_data", "workspaces")
+
+
+def _slug(s: str) -> str:
+    """Conservative slug: lowercase, [a-z0-9_] only. Empty if input is unusable."""
+    return re.sub(r"[^a-z0-9_]+", "_", str(s).lower()).strip("_")
+
+
+def _resolve_caller_id() -> Optional[str]:
+    """Walk the stack outward looking for a frame whose module defines
+    __manifest__ with a usable id/name. Skip our own module frames."""
+    for frame_info in inspect.stack()[1:]:
+        mod = inspect.getmodule(frame_info.frame)
+        if mod is None or mod.__name__ == __name__:
+            continue
+        manifest = getattr(mod, "__manifest__", None)
+        if isinstance(manifest, dict):
+            cand = manifest.get("id") or manifest.get("name")
+            if cand:
+                slug = _slug(cand)
+                if slug:
+                    return slug
+    return None
+
+
+def workspace_root() -> Path:
+    """Base dir that holds all per-rapp workspaces. Used by the HTTP service."""
+    return Path(_WORKSPACE_BASE)
+
+
+def workspace_dir(rapp_id: Optional[str] = None) -> Optional[Path]:
+    """Return the calling rapp's workspace dir, creating it if absent.
+
+    If rapp_id is omitted, walks the call stack to find the caller's
+    __manifest__ and uses its id (or name). Returns None if no rapp
+    identity can be determined — singletons MUST handle that case
+    rather than crashing (running outside a brainstem, e.g. tests).
+    """
+    rid = _slug(rapp_id) if rapp_id else _resolve_caller_id()
+    if not rid:
+        return None
+    p = Path(_WORKSPACE_BASE) / rid
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def ensure_workspace(rapp_id: str) -> Optional[Path]:
+    """Create-and-return a workspace for the given rapp id. No-op if it
+    already exists. Used by the binder's install hook. Returns None for
+    invalid ids rather than raising — install paths shouldn't fail just
+    because a rapp has a weird name."""
+    rid = _slug(rapp_id)
+    if not rid:
+        return None
+    p = Path(_WORKSPACE_BASE) / rid
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def safe_workspace_path(rapp_id: str, name: str) -> Optional[Path]:
+    """Resolve `<workspace>/<name>` while rejecting any path traversal.
+
+    `name` is treated as a relative leaf — segments containing '..',
+    absolute paths, or anything that would resolve outside the rapp's
+    workspace dir return None. The HTTP service relies on this guard.
+    """
+    rid = _slug(rapp_id)
+    if not rid or not name:
+        return None
+    # Reject obvious traversal up front
+    if name.startswith(("/", "\\")) or ".." in name.replace("\\", "/").split("/"):
+        return None
+    base = (Path(_WORKSPACE_BASE) / rid).resolve()
+    base.mkdir(parents=True, exist_ok=True)
+    target = (base / name).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError:
+        return None
+    return target
+
+
+def list_workspace(rapp_id: str) -> list[dict]:
+    """List files in the rapp's workspace as [{name, size, mtime}].
+    Subdirectories are walked one level so 'subdir/file.txt' surfaces.
+    Returns [] if the workspace doesn't exist yet."""
+    rid = _slug(rapp_id)
+    if not rid:
+        return []
+    base = Path(_WORKSPACE_BASE) / rid
+    if not base.is_dir():
+        return []
+    out = []
+    for p in sorted(base.rglob("*")):
+        if not p.is_file():
+            continue
+        try:
+            rel = p.relative_to(base).as_posix()
+            st = p.stat()
+            out.append({"name": rel, "size": st.st_size, "mtime": int(st.st_mtime)})
+        except OSError:
+            continue
+    return out


### PR DESCRIPTION
## Summary

Implements [SPEC §11](https://github.com/kody-w/RAPP_Store/blob/main/SPEC.md#11-workspace-contract-per-rapp-file-scratchpad) / [Proposal 0004](https://github.com/kody-w/RAPP_Store/blob/main/docs/proposals/0004-per-rapp-workspaces.md) — every installed rapplication gets its own collaborative workspace dir at `.brainstem_data/workspaces/<id>/` where the user and the rapp can exchange files.

- `utils/workspace.py` (new) — `workspace_dir()` walks the call stack to the caller's `__manifest__` and returns the resolved `Path`. `safe_workspace_path()` rejects path traversal.
- Binder install hooks (store install, drag-drop `.py`, `.egg` import) all call `ensure_workspace(rapp_id)`. Uninstall preserves the dir — it's user data.
- New HTTP routes on `/api/binder/workspace/<id>/`: `info`, `list`, `file/<name>` (GET/PUT/DELETE), `reveal` (open in Finder).
- Chat UI postMessage bridge handles `rapp:workspace:list/read/write/delete/reveal/request_files`. Cartridge envelope now carries a `workspace` block (path, mode, file_count).

Distinct from the existing `.brainstem_data/<id>/` rapp-private state (still bundled into eggs as `state/...`). Workspaces are user-collaborative and intentionally NOT auto-bundled — large user files don't belong in shippable cartridges.

## Test plan

- [x] All three modified Python files parse cleanly.
- [x] `_slug` round-trips; `ensure_workspace` mkdir's; manifest stack-walk resolves through a real importable module.
- [x] Path traversal rejected: `../escape`, `/etc/passwd`, `a/../../escape`, `..\windows`.
- [x] E2E via `binder_service.handle()`: PUT → list → GET (correct binary tuple + MIME) → DELETE → list confirms removal.
- [x] Subdir writes (`subdir/file.txt`) work; base64 binary round-trip works.
- [ ] Manual: drop a `.py` agent on a running brainstem, confirm `.brainstem_data/workspaces/<id>/` appears.
- [ ] Manual: install a rapp from the store, confirm workspace dir appears and `rapp:workspace:reveal` opens it in Finder.
- [ ] Manual: from a rapp's iframe, post `rapp:workspace:write` with a CSV and verify it lands in the right dir.

## Known gaps (out of scope for v1)

- No "Workspace drawer" in the chat UI yet — `request_files` surfaces as a chat message instead. Iframes can render their own "Open folder" button via `rapp:workspace:reveal`, which is enough to ship.
- vBrainstem (cloud) emulation lives in `kody-w/RAPP_Store`'s `vbrainstem.html` — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)