### PR TITLE
brainstem UI: drop hardcoded :7071, use same-origin

### DIFF
--- a/rapp_brainstem/index.html
+++ b/rapp_brainstem/index.html
@@ -1473,8 +1473,9 @@
 </footer>
 
 <script>
-  // Auto-detect: if served from a different port (e.g. Live Server), proxy to brainstem on 7071
-  const API = location.port === '7071' ? '' : `${location.protocol}//${location.hostname}:7071`;
+  // Same-origin: the page is served by the brainstem itself, so use whatever port that is.
+  // (Project-local installs from `install.sh --here` pick a free port that may not be 7071.)
+  const API = '';
   let sessionId = null;
   let history = [];
   let fullTranscript = [];


### PR DESCRIPTION
## Summary
- The frontend assumed the brainstem always listens on `:7071`. When `install.sh --here` (project-local) picks a different port to avoid colliding with a global brainstem, the UI tries to fetch `localhost:7071/health`, `/agents`, `/voice/config` etc. and fails with `ERR_CONNECTION_REFUSED`.
- Since `index.html` is served by the brainstem process itself, the right base URL is always **same-origin** — so the port-detection branch becomes dead weight.

## Repro (before this PR)
```bash
curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash -s -- --here
echo 7074 > .brainstem/PORT
.brainstem/start.sh
open http://localhost:7074/
```
Browser console:
```
:7071/voice/config   net::ERR_CONNECTION_REFUSED
:7071/voice          net::ERR_CONNECTION_REFUSED
:7071/agents         net::ERR_CONNECTION_REFUSED
:7071/health         net::ERR_CONNECTION_REFUSED  (×6, retried)
loadAgentsList ((index):2056) → TypeError: Failed to fetch
```

## Fix
`rapp_brainstem/index.html`:
```diff
-  // Auto-detect: if served from a different port (e.g. Live Server), proxy to brainstem on 7071
-  const API = location.port === '7071' ? '' : `${location.protocol}//${location.hostname}:7071`;
+  // Same-origin: the page is served by the brainstem itself, so use whatever port that is.
+  // (Project-local installs from `install.sh --here` pick a free port that may not be 7071.)
+  const API = '';
```

The Live-Server use case noted in the old comment isn't broken — anyone proxying the static HTML through a different dev server would have to point it at the brainstem regardless; hardcoding `:7071` only worked when the global brainstem happened to be running there.

## Test plan
- [x] Project-local install on a non-7071 port — UI loads agents, health badge goes green
- [ ] Global install on `:7071` (default) — same-origin still works (`API = ''` resolves correctly)
- [ ] Confirm no other code path depends on the absolute-URL form of `API`