### PR TITLE
installer: slim clone — only check out rapp_brainstem/

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -328,6 +328,20 @@ check_prereqs() {
     fi
 }
 
+# Slim clone: pull only rapp_brainstem/ from kody-w/RAPP via partial +
+# sparse-checkout. The brainstem is the only tier the install one-liner
+# needs to materialize; rapp_swarm/, worker/, pages/, tests/, installer/
+# stay in the object DB and can still be checked out on demand
+# (e.g. binder_service.py restore at line ~580 — git keeps the blobs).
+# Users who later want the swarm tier or worker run their own clone.
+clone_brainstem_sparse() {
+    local dest="$1"
+    git clone --quiet --filter=blob:none --no-checkout "$REPO_URL" "$dest" || return 1
+    git -C "$dest" sparse-checkout init --cone
+    git -C "$dest" sparse-checkout set rapp_brainstem
+    git -C "$dest" checkout --quiet main
+}
+
 install_brainstem() {
     echo ""
     echo "Installing RAPP Brainstem..."
@@ -414,12 +428,7 @@ install_brainstem() {
                 echo "  Re-cloning from scratch to recover..."
                 cd "$BRAINSTEM_HOME"
                 rm -rf "$BRAINSTEM_HOME/src"
-                # Full clone — users typically deploy the swarm tier and worker
-                # later, and the install one-liner is the path everyone takes.
-                # The catalog (rapp_store) is the only repo that's been split out;
-                # everything else (rapp_brainstem, rapp_swarm, worker, installer,
-                # pages, tests) ships as a single tree.
-                if git clone --quiet "$REPO_URL" "$BRAINSTEM_HOME/src"; then
+                if clone_brainstem_sparse "$BRAINSTEM_HOME/src"; then
                     if [ -n "$PIN_TAG" ]; then
                         cd "$BRAINSTEM_HOME/src"
                         git checkout --quiet "$PIN_TAG" 2>/dev/null || \
@@ -476,10 +485,7 @@ install_brainstem() {
     else
         echo "  Fresh install — cloning repository..."
         rm -rf "$BRAINSTEM_HOME/src" 2>/dev/null || true
-        # Full clone of kody-w/RAPP — engine, swarm, worker, installer, pages,
-        # tests. The rapp_store catalog is in a separate repo, fetched at
-        # runtime via RAPPSTORE_URL.
-        git clone --quiet "$REPO_URL" "$BRAINSTEM_HOME/src"
+        clone_brainstem_sparse "$BRAINSTEM_HOME/src"
         if [ -n "$PIN_TAG" ]; then
             cd "$BRAINSTEM_HOME/src"
             if git checkout --quiet "$PIN_TAG" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Switches the install one-liner from a full clone of `kody-w/RAPP` (~7.7 MB) to a partial + sparse-checkout that only materializes `rapp_brainstem/` (~1.6 MB).
- Drives the change at the only two clone sites in `install.sh` (fresh install + recovery re-clone) via a single `clone_brainstem_sparse` helper. Same `REPO_URL`, same one-liner URL — Article V intact.
- Most visible win: **project-local installs** (`--here`). Today the full tree of `rapp_swarm/`, `worker/`, `pages/`, `tests/`, `installer/`, marketing HTML lights up the user's project sidebar. After this, all they see under `.brainstem/src/` is `rapp_brainstem/` — the only tier the brainstem actually runs.

## How it works

```
git clone --filter=blob:none --no-checkout $REPO_URL ...
git sparse-checkout init --cone
git sparse-checkout set rapp_brainstem
git checkout main
```

Blobs outside the cone stay in the object DB. The existing binder restore path (`install.sh:~580`) already calls out that it works with sparse-checkout — git fetches the blob on demand if ever needed. Users who later want `rapp_swarm/` or `worker/` run their own clone — the catalog (`rapp_store`) is already split out, so this is consistent with the direction of travel.

## Compatibility

- Upgrade path unchanged. `git fetch --tags origin main` + `git reset --hard origin/main` work the same with sparse+partial.
- `BRAINSTEM_VERSION=X.Y.Z` pin still works — `git checkout $PIN_TAG` respects the existing sparse cone.
- No version bump on `rapp_brainstem/VERSION` — the brainstem itself is unchanged.

## Test plan

- [ ] Fresh global install: `curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash` → `~/.brainstem/src/` only contains `rapp_brainstem/` + `.git/`.
- [ ] Fresh project-local: `curl ... | bash -s -- --here` → `./.brainstem/src/` only contains `rapp_brainstem/` + `.git/`.
- [ ] Re-run installer on existing brainstem → upgrade path (fetch + reset) succeeds.
- [ ] Pinned install: `BRAINSTEM_VERSION=0.12.2 curl ... | bash` → checks out tag, sparse-cone preserved.
- [ ] Binder restore: delete `rapp_brainstem/utils/services/binder_service.py`, re-run installer → file restored from object DB.
- [ ] `du -sh ~/.brainstem/src` → ~1.6 MB instead of ~7.7 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)