### PR TITLE
Fix ESTATE_SPEC door_type row to match the Art. XLVI.2 amendment

### DIFF
--- a/pages/docs/ESTATE_SPEC.md
+++ b/pages/docs/ESTATE_SPEC.md
@@ -27,7 +27,7 @@ From this string alone, by **string parsing** (not lookup, not config, not env),
 | `kind` | The token between `rappid:v2:` and `:@` |
 | `owner` | Everything after `@` and before `/` in the first segment |
 | `repo` | Everything after `/` and before `:` in the first segment |
-| `door_type` | `"front_door"` if `kind == "twin"`, else `"gate"` (XLVI.2) |
+| `door_type` | `"front_door"` if `kind` ∈ `_FRONT_DOOR_KINDS` (`twin`, `operator`, … — the full set is the **Valid kinds** row below), else `"gate"` (XLVI.2) |
 
 **Valid kinds** (frozen as of 2026-05-09; **amended 2026-06-02** per CONSTITUTION Art. XLVI.2 to ratify the single-presence kinds already shipped across the kernel, RAR, and RAPP-Network): single AI presences → `front_door`: `twin`, `operator`, `personal`, `project`, `memorial`, `pre-founder`, `mirror`, `experiment`, `place`, `custom`; community spaces you enter → `gate`: `neighborhood`, `ant-farm`, `braintrust`, `workspace`, `hatched`, `rapplication`, `prototype`. Adding a new kind requires a CONSTITUTION amendment because every consumer derives behavior from this token; the canonical machine-readable set is `VALID_KINDS` / `_FRONT_DOOR_KINDS` in `tools/door_address.py` (the one parser consumers MUST import).
 


### PR DESCRIPTION
The parse table still said door_type = front_door if kind=='twin' else gate. Update it to reference the full _FRONT_DOOR_KINDS set (per the 2026-06-02 amendment + tools/door_address.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)