### PR TITLE
Amend rappid format to the Eternity standard (canonical)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -2369,15 +2369,23 @@ canonical spec at `pages/vault/Architecture/Rappid.md`:
 }
 ```
 
-**Format unification (ratified 2026-04-30).** There is exactly one
-rappid format: the v2 unified specification. A draft `1.1` schema with
-bare-UUID rappids existed briefly during April 2026; existing UUIDs
-(notably the species root's `0b635450-c042-49fb-b4b1-bdb571044dec`)
-were preserved by being placed in the hash field of the v2 string
-(dashes stripped). No rappid was lost in the migration. **No future
-article shall introduce parallel formats** — see `pages/vault/Architecture/Rappid.md`
-for the antipattern principle. The species tree is one tree, and one
-identifier system traverses it.
+**Eternity amendment (locked 2026-06-01) — supersedes the 2026-04-30 v2 format.**
+The canonical rappid is now the minimal, eternal form `rappid:<slug>:<64hex>`:
+an immutable birth-slug and the **full 256-bit SHA-256** identity hash (never
+truncated). The hash is the identity and the join key; matching is always on the
+hash. **The string is never re-versioned** — all structure (kind, publisher, host,
+ownership keypair, succession, attestation) lives in the `rappid.json` record as
+additive, versionless fields. Canonical spec: `pages/vault/Architecture/Rappid.md`;
+reference implementation: `kody-w/rapp-egg-hub` SPEC §2. The species tree is one
+tree, one identifier system traverses it, and that identifier is the Eternity hash.
+
+**Compatibility (the v2 form is now legacy).** The 2026-04-30 v2 unified format
+(`rappid:v2:<kind>:@<publisher>/<slug>:<hash>@<home_vault_url>`) and the brief draft
+`1.1` bare-UUID form are **legacy + addressing forms**: read forever, extract the
+64-hex hash, and canonicalize to Eternity — but no longer emitted as identity. No
+rappid is lost (the species root's `0b635450-c042-49fb-b4b1-bdb571044dec` canonicalizes
+losslessly). **No future article shall introduce a parallel *identity* format**; the
+record carries new richness, never the string.
 
 The rappid is **never regenerated**. It is the organism's permanent
 identity. Backing up the org to a new repo, hatching, reverting,

--- a/pages/docs/ESTATE_SPEC.md
+++ b/pages/docs/ESTATE_SPEC.md
@@ -12,7 +12,9 @@ If you are writing a planter, an estate agent, a federation walker, a holocard r
 
 ## 1. The rappid IS the URL
 
-The canonical v2 rappid format:
+> **Note (Eternity amendment, 2026-06-01):** the canonical rappid *identity* is the Eternity form `rappid:<slug>:<64hex>` (CONSTITUTION Art. XXXIV.1 / `pages/vault/Architecture/Rappid.md`). The v2 form below is the **door *addressing* form** — read-compatible, carrying the routing fields inline; door resolution from a bare Eternity identity reads them from the `rappid.json` record.
+
+The v2 rappid addressing format:
 
 ```
 rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner>/<repo>

--- a/pages/vault/Architecture/Rappid.md
+++ b/pages/vault/Architecture/Rappid.md
@@ -9,7 +9,7 @@ hook: Rappid is the public ID — one format, one concept — for every digital 
 
 > **Hook.** Rappid is the public ID — one format, one concept — for every digital organism that descends from RAPP. The species' social-security number. The species tree's lingua franca. There is no other identifier system; there will never be a divergent format.
 
-This note is the canonical specification for the rappid identity system. It is intentionally short, intentionally singular, and intentionally final on the format question. Subsidiary notes elaborate on lineage, signing, and operational tooling — but every reference back to "what is a rappid" lands here.
+This note is the canonical specification for the rappid identity system. It is intentionally short and intentionally singular; the format question is settled by the **Eternity amendment (2026-06-01)** below, which supersedes the 2026-04-30 v2 format. Subsidiary notes elaborate on lineage, signing, and operational tooling — but every reference back to "what is a rappid" lands here.
 
 ## What rappid is
 
@@ -24,7 +24,23 @@ Rappids:
 
 Think of a rappid as the species' social-security number. Universal. Singular. The unit of accounting for digital biology.
 
-## The format (one format, forever)
+## The format
+
+> **AMENDMENT — the Eternity standard, locked 2026-06-01 (supersedes the 2026-04-30 v2 format).**
+> The **canonical** rappid is the minimal, eternal form:
+>
+> ```
+> rappid:<slug>:<64hex>
+> ```
+>
+> - `<slug>` — the immutable **birth name** (gene name + routing hint); self-verifying because it is the literal `name_slot` that derived the hash.
+> - `<64hex>` — the **full 256-bit SHA-256** identity hash, **never truncated to 128**. The hash is the identity and the **join key**: matching/dedup is ALWAYS on the hash, never the slug.
+> - **The string is never re-versioned** (that was the v2/v3 mistake). ALL structure — kind, publisher, host, ownership keypair (`pubkey`/`sig_suite`), `birth_attestation`, `key_succession`, `registry_anchor` — lives in the `rappid.json` **record** as additive, versionless fields.
+> - Reference implementation: `kody-w/rapp-egg-hub` SPEC §2. Rationale (256-bit is the one irreversible choice, sized for an eternal bloodline registry even post-Grover; keypair-bound ownership so a line survives the operator; crypto-agility via the record's `sig_suite`) is locked.
+>
+> **Compatibility contract:** consumers **read every legacy form forever** and **emit only** the canonical Eternity string. The **v2-structured** form below is now a **legacy + addressing form**: read it, *extract the 64-hex hash* (the `v2`/`@host`/kind decorations are record concerns, not string concerns), and canonicalize to Eternity. It is no longer the canonical identity.
+
+The legacy / addressing form (ratified 2026-04-30; read-compatible, no longer emitted):
 
 ```
 rappid:v2:<kind>:@<publisher>/<slug>:<hash>@<home_vault_url>

--- a/tools/door_address.py
+++ b/tools/door_address.py
@@ -2,6 +2,15 @@
 
 Authority: pages/docs/ESTATE_SPEC.md (CONSTITUTION Article XLVI).
 
+Identity vs. addressing: the CANONICAL rappid *identity* is the Eternity form
+`rappid:<slug>:<64hex>` (CONSTITUTION Art. XXXIV.1, locked 2026-06-01) — slug + the
+256-bit hash, with kind/owner/host living in the rappid.json record. This module
+parses the LEGACY v2-structured *addressing* form
+(`rappid:v2:<kind>:@<owner>/<slug>:<hash>@<host>`), which carries the door-routing
+fields inline. It is read-compatible per the compatibility contract (read every
+legacy form, emit Eternity); door resolution from a bare Eternity identity string
+reads those routing fields from the record instead.
+
 This is the SINGLE implementation of the Estate Spec's `door_from_rappid()`
 contract (ESTATE_SPEC §5). Every consumer that maps rappid → door URLs uses
 this module — never reinvents the parsing, never patches around it.


### PR DESCRIPTION
Propagates your **2026-06-01 Eternity lock** back into the constitution — it had never been applied to `Rappid.md`/`CONSTITUTION`/`door_address.py`, which were stuck on the superseded **2026-04-30 v2** form.

**Canonical now:** `rappid:<slug>:<64hex>` — birth-slug + full **256-bit** SHA-256 (the hash is the identity + join key; the string is **never re-versioned**; all structure lives in the `rappid.json` record). Reference impl: `kody-w/rapp-egg-hub` SPEC §2.

**v2-structured becomes legacy + addressing:** read forever → extract the 64-hex hash → emit Eternity (per the compatibility contract). `door_address.py` keeps reading the v2 *addressing* form (docstring-only change, no regex/code touched).

Sites: `Rappid.md` (the canonical spec), `CONSTITUTION Art. XXXIV.1`, `ESTATE_SPEC`, `door_address.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)