### PR TITLE
Phase A: lock the self-locating Eternity rappid as canonical

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -2369,15 +2369,25 @@ canonical spec at `pages/vault/Architecture/Rappid.md`:
 }
 ```
 
-**Format unification (ratified 2026-04-30).** There is exactly one
-rappid format: the v2 unified specification. A draft `1.1` schema with
-bare-UUID rappids existed briefly during April 2026; existing UUIDs
-(notably the species root's `0b635450-c042-49fb-b4b1-bdb571044dec`)
-were preserved by being placed in the hash field of the v2 string
-(dashes stripped). No rappid was lost in the migration. **No future
-article shall introduce parallel formats** — see `pages/vault/Architecture/Rappid.md`
-for the antipattern principle. The species tree is one tree, and one
-identifier system traverses it.
+**Eternity amendment (locked 2026-06-01, self-locating refinement finalized
+2026-06-03) — supersedes the 2026-04-30 v2 format.** The canonical rappid is the
+**self-locating Eternity form** `rappid:@<owner>/<slug>:<64hex>`: an `@<owner>/<slug>`
+locator (the door is at `github.com/<owner>/<slug>` — preserves Article XLVI zero-lookup
+discovery) and the **full 256-bit SHA-256** identity hash (never truncated). The hash is
+the identity and the join key. **The string is never re-versioned** — all other structure
+(`kind`→`door_type`, ownership keypair, succession, attestation, `parent_rappid`,
+`home_vault`) lives in the `rappid.json` record as additive, versionless fields. Canonical
+spec: `pages/vault/Architecture/Rappid.md`; reference implementation: `kody-w/rapp-egg-hub`
+SPEC §2. The species tree is one tree, one identifier traverses it, and that identifier is
+the self-locating Eternity rappid.
+
+**Compatibility (the v2 form is now legacy).** The 2026-04-30 v2 unified format
+(`rappid:v2:<kind>:@<owner>/<slug>:<32hex>@<host>`) and the brief draft `1.1` bare-UUID form
+are **legacy forms**: read forever, canonicalize to Eternity (extract `@<owner>/<slug>`;
+recompute the 64-hex hash from the master pubkey, else re-anchor with the old string in
+`_migrated_from`), but **no longer emitted**. No rappid is lost (the species root's
+`0b635450-c042-49fb-b4b1-bdb571044dec` canonicalizes losslessly). **No future article shall
+introduce a parallel *identity* format**; the record carries new richness, never the string.
 
 The rappid is **never regenerated**. It is the organism's permanent
 identity. Backing up the org to a new repo, hatching, reverting,

--- a/pages/docs/ESTATE_SPEC.md
+++ b/pages/docs/ESTATE_SPEC.md
@@ -12,7 +12,9 @@ If you are writing a planter, an estate agent, a federation walker, a holocard r
 
 ## 1. The rappid IS the URL
 
-The canonical v2 rappid format:
+> **Eternity amendment (2026-06-03).** The canonical rappid is the **self-locating Eternity form** `rappid:@<owner>/<slug>:<64hex>` (CONSTITUTION Art. XXXIV.1 / `pages/vault/Architecture/Rappid.md`). It keeps the zero-lookup discovery property below — `owner`/`repo` parse straight out of the `@<owner>/<slug>` locator — while the identity is the full 256-bit hash and `kind` (→ `door_type`) is read from the door's `rappid.json` record. The v2 form below is the **legacy door-addressing form**: read-compatible, no longer emitted. `door_from_rappid()` reads both; for the Eternity form it derives every URL from `@<owner>/<slug>` and takes `kind` from `rappid.json::kind`.
+
+The legacy v2 rappid addressing format:
 
 ```
 rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner>/<repo>

--- a/pages/vault/Architecture/Rappid.md
+++ b/pages/vault/Architecture/Rappid.md
@@ -26,9 +26,23 @@ Think of a rappid as the species' social-security number. Universal. Singular. T
 
 ## The format (one format, forever)
 
-```
-rappid:v2:<kind>:@<publisher>/<slug>:<hash>@<home_vault_url>
-```
+> **AMENDMENT — the Eternity standard, self-locating refinement (locked 2026-06-01, finalized 2026-06-03). This is THE canonical rappid; everything below it is legacy.**
+>
+> ```
+> rappid:@<owner>/<slug>:<64hex>
+> ```
+>
+> - `@<owner>/<slug>` — **locator + namespace**. `<slug>` is the immutable birth name (gene name); `<owner>` is the publishing handle. The pair makes the rappid **self-locating**: the door lives at `github.com/<owner>/<slug>`, served at `<owner>.github.io/<slug>`, identity at `raw.githubusercontent.com/<owner>/<slug>/main/rappid.json` — all derivable from the string with **zero lookup** (preserves Article XLVI / ESTATE_SPEC discovery).
+> - `<64hex>` — the **full 256-bit SHA-256** identity hash, **never truncated to 128**. The hash is the identity and the **join key**: matching/dedup is ALWAYS on the hash.
+> - **Everything else lives in the `rappid.json` record** as additive, versionless fields: `kind` (→ `door_type`), `pubkey`, `sig_suite`, `birth_attestation`, `key_succession`, `registry_anchor`, `parent_rappid`, and `home_vault` (a non-GitHub canonical home, when not the default `github.com/<owner>/<slug>`). **The string is never re-versioned** — that was the v2/v3 mistake.
+> - Reference implementation: `kody-w/rapp-egg-hub` SPEC §2.
+>
+> **Compatibility contract:** consumers **read every legacy form forever** and **emit only** the canonical Eternity string. Legacy forms and how they canonicalize:
+> - **v2** `rappid:v2:<kind>:@<owner>/<slug>:<32hex>@<host>` — take `@<owner>/<slug>`; `kind`/`host` move to the record; the 32-hex hash is recomputed to the full 64-hex from the master pubkey (`sha256(pubkey_SPKI)`) when present, else the door is re-anchored once (old string preserved in `_migrated_from`).
+> - **bare Eternity** `rappid:<slug>:<64hex>` — prepend `@<owner>/` from the record.
+> - **bare UUID** (draft v1) — genesis re-anchor; the UUID is preserved in `_migrated_from`.
+>
+> The v2-structured form below is the legacy door-addressing form (ratified 2026-04-30): read-compatible, **no longer emitted**.
 
 | Field | Meaning |
 |---|---|

--- a/tests/test_door_address.py
+++ b/tests/test_door_address.py
@@ -1,0 +1,56 @@
+"""Tests for tools/door_address.py — the one rappid → door parser.
+
+Covers the canonical self-locating Eternity form `rappid:@<owner>/<slug>:<64hex>`
+(CONSTITUTION Art. XXXIV.1) and the legacy v2 form (read-compatible).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+import door_address as d  # noqa: E402
+
+H64 = "a" * 64
+H32 = "b" * 32
+V2 = f"rappid:v2:twin:@kody-w/echo-brainstem:{H32}@github.com/kody-w/echo-brainstem"
+
+
+def test_eternity_canonical_with_kind():
+    e = d.door_from_rappid(f"rappid:@kody-w/echo-brainstem:{H64}", kind="twin")
+    assert e["owner"] == "kody-w" and e["repo"] == "echo-brainstem"
+    assert e["kind"] == "twin" and e["door_type"] == "front_door"
+    assert e["urls"]["identity"] == "https://raw.githubusercontent.com/kody-w/echo-brainstem/main/rappid.json"
+    assert e["urls"]["front"] == "https://kody-w.github.io/echo-brainstem/"
+
+
+def test_eternity_without_kind_still_self_locates():
+    e = d.door_from_rappid(f"rappid:@kody-w/echo-brainstem:{H64}")
+    assert e["kind"] is None and e["door_type"] is None
+    assert e["urls"]["repo"] == "https://github.com/kody-w/echo-brainstem"
+
+
+def test_legacy_v2_unchanged():
+    l = d.door_from_rappid(V2)
+    assert l["owner"] == "kody-w" and l["kind"] == "twin" and l["door_type"] == "front_door"
+
+
+def test_owner_repo_from_both_forms():
+    assert d.owner_repo_from_rappid(f"rappid:@kody-w/x:{H64}") == ("kody-w", "x")
+    assert d.owner_repo_from_rappid(V2) == ("kody-w", "echo-brainstem")
+
+
+def test_invalid_forms_raise():
+    for bad in ["nonsense", f"rappid:@kody-w/x:{H32}",  # 32-hex is too short for Eternity
+                f"rappid:v2:twin:@a/b:{H32}@github.com/a/c"]:  # v2 origin mismatch
+        try:
+            d.door_from_rappid(bad)
+            assert False, f"should have raised for {bad!r}"
+        except d.InvalidRappidError:
+            pass
+
+
+def test_unknown_kind_rejected():
+    try:
+        d.door_from_rappid(f"rappid:@a/b:{H64}", kind="bogus")
+        assert False, "bogus kind should raise"
+    except d.InvalidRappidError:
+        pass

--- a/tools/door_address.py
+++ b/tools/door_address.py
@@ -2,6 +2,12 @@
 
 Authority: pages/docs/ESTATE_SPEC.md (CONSTITUTION Article XLVI).
 
+Canonical form: the self-locating Eternity rappid `rappid:@<owner>/<slug>:<64hex>`
+(CONSTITUTION Art. XXXIV.1, finalized 2026-06-03) — owner/slug locate the door, the
+256-bit hash is the identity, and `kind` lives in the door's rappid.json record.
+The legacy v2 form (`rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`)
+is read-compatible per the compatibility contract (read every legacy form, emit Eternity).
+
 This is the SINGLE implementation of the Estate Spec's `door_from_rappid()`
 contract (ESTATE_SPEC §5). Every consumer that maps rappid → door URLs uses
 this module — never reinvents the parsing, never patches around it.
@@ -19,7 +25,16 @@ from __future__ import annotations
 import re
 
 
-# Canonical v2 rappid regex — anchored, no wiggle room.
+# Canonical: the self-locating Eternity rappid (CONSTITUTION Art. XXXIV.1, 2026-06-03).
+# rappid:@<owner>/<slug>:<64hex> — owner/slug locate the door; the 256-bit hash is the
+# identity; `kind` is NOT in the string (it lives in the rappid.json record and is passed
+# to door_from_rappid). 64 lowercase hex = full SHA-256, never the truncated 32.
+_ETERNITY_RE = re.compile(
+    r"^rappid:@(?P<owner>[A-Za-z0-9][A-Za-z0-9._-]*)/(?P<slug>[A-Za-z0-9][A-Za-z0-9._-]*):"
+    r"(?P<hex>[a-f0-9]{64})$"
+)
+
+# Legacy v2 rappid addressing regex — read-compatible, no longer emitted.
 # rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner2>/<repo2>
 # Where (owner, repo) MUST equal (owner2, repo2) — that equality is checked
 # explicitly below because regex backreferences make the pattern unreadable.
@@ -69,63 +84,15 @@ class InvalidRappidError(ValueError):
     """
 
 
-def door_from_rappid(rappid: str) -> dict:
-    """Return the canonical door object for a rappid. Pure function.
-
-    Implements the contract in ESTATE_SPEC §5.
-
-    Args:
-      rappid: the v2 rappid string.
-
-    Returns:
-      A dict with the keys: rappid, owner, repo, kind, door_type, urls.
-      `urls` is a dict with keys: repo, front, identity, holocard, holo_md,
-      avatar, summon_qr, members, facets. The `members` URL is included for
-      ALL doors but is only populated content for gates — twins return an
-      empty members.json (or 404). Consumers that distinguish should check
-      door_type first.
-
-    Raises:
-      InvalidRappidError: if the string is not a valid v2 rappid, OR the
-        (owner, repo) on the left of the rappid don't match the (owner, repo)
-        on the right (the @github.com/... origin pin), OR kind is not in
-        VALID_KINDS.
-    """
-    if not isinstance(rappid, str):
-        raise InvalidRappidError(f"rappid must be a string, got {type(rappid).__name__}")
-
-    m = _RAPPID_RE.match(rappid)
-    if not m:
-        raise InvalidRappidError(
-            f"rappid does not match v2 format: {rappid!r}. "
-            f"Expected: rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>"
-        )
-
-    owner = m.group("owner")
-    repo = m.group("repo")
-    owner2 = m.group("owner2")
-    repo2 = m.group("repo2")
-    kind = m.group("kind")
-
-    if owner != owner2 or repo != repo2:
-        raise InvalidRappidError(
-            f"rappid origin mismatch: identity says @{owner}/{repo}, "
-            f"origin pin says @github.com/{owner2}/{repo2}. The two MUST be equal."
-        )
-
-    if kind not in VALID_KINDS:
-        raise InvalidRappidError(
-            f"rappid kind {kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
-            f"Adding a kind requires a CONSTITUTION amendment (Article XLVI)."
-        )
-
+def _door_dict(rappid: str, owner: str, repo: str, kind: str | None) -> dict:
+    """Build the canonical door object from a located (owner, repo) and optional kind."""
     raw_base = f"https://raw.githubusercontent.com/{owner}/{repo}/main"
     return {
         "rappid": rappid,
         "owner": owner,
         "repo": repo,
         "kind": kind,
-        "door_type": _door_type_for_kind(kind),
+        "door_type": _door_type_for_kind(kind) if kind else None,
         "urls": {
             "repo":      f"https://github.com/{owner}/{repo}",
             "front":     f"https://{owner}.github.io/{repo}/",
@@ -138,6 +105,67 @@ def door_from_rappid(rappid: str) -> dict:
             "facets":    f"{raw_base}/facets.json",
         },
     }
+
+
+def door_from_rappid(rappid: str, kind: str | None = None) -> dict:
+    """Return the canonical door object for a rappid. Pure function.
+
+    Implements the contract in ESTATE_SPEC §5. Accepts the **canonical self-locating
+    Eternity** rappid `rappid:@<owner>/<slug>:<64hex>` and the **legacy v2** form
+    `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`.
+
+    Args:
+      rappid: the rappid string (Eternity canonical, or legacy v2).
+      kind: the organism kind, read from the door's rappid.json record. Used only for the
+        Eternity form (whose string carries no kind); ignored for v2 (kind parsed from the
+        string). If omitted for an Eternity rappid, `kind` and `door_type` come back None.
+
+    Returns:
+      A dict with keys: rappid, owner, repo, kind, door_type, urls. `urls` has keys:
+      repo, front, identity, holocard, holo_md, avatar, summon_qr, members, facets. The
+      `members` URL is populated only for gates; twins return an empty members.json (or 404).
+
+    Raises:
+      InvalidRappidError: if the string matches neither the canonical Eternity form nor the
+        legacy v2 form; if a v2 rappid's left (owner, repo) != its origin pin; or if a
+        supplied kind is not in VALID_KINDS.
+    """
+    if not isinstance(rappid, str):
+        raise InvalidRappidError(f"rappid must be a string, got {type(rappid).__name__}")
+
+    # Canonical: the self-locating Eternity form. owner/slug locate the door; kind (and
+    # thus door_type) comes from the record, supplied by the caller.
+    em = _ETERNITY_RE.match(rappid)
+    if em:
+        if kind is not None and kind not in VALID_KINDS:
+            raise InvalidRappidError(
+                f"rappid kind {kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
+                f"Adding a kind requires a CONSTITUTION amendment (Article XLVI)."
+            )
+        return _door_dict(rappid, em.group("owner"), em.group("slug"), kind)
+
+    # Legacy: the v2 addressing form. kind is parsed from the string.
+    m = _RAPPID_RE.match(rappid)
+    if not m:
+        raise InvalidRappidError(
+            f"rappid matches neither the canonical Eternity form "
+            f"(rappid:@<owner>/<slug>:<64hex>) nor the legacy v2 form: {rappid!r}"
+        )
+
+    owner = m.group("owner")
+    repo = m.group("repo")
+    if owner != m.group("owner2") or repo != m.group("repo2"):
+        raise InvalidRappidError(
+            f"rappid origin mismatch: identity says @{owner}/{repo}, origin pin says "
+            f"@github.com/{m.group('owner2')}/{m.group('repo2')}. The two MUST be equal."
+        )
+    v2_kind = m.group("kind")
+    if v2_kind not in VALID_KINDS:
+        raise InvalidRappidError(
+            f"rappid kind {v2_kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
+            f"Adding a kind requires a CONSTITUTION amendment (Article XLVI)."
+        )
+    return _door_dict(rappid, owner, repo, v2_kind)
 
 
 def estate_url(github_handle: str) -> str:


### PR DESCRIPTION
**The keystone** of the v2→Eternity migration: makes `rappid:@<owner>/<slug>:<64hex>` the canonical rappid across the canon.

- **Self-locating** (`@owner/slug` → the door) so Article XLVI zero-lookup discovery is preserved — this dissolves the blocker that a bare `<slug>:<64hex>` can't find its door.
- **256-bit** SHA-256 identity + join key; `kind`/keypair/parent/home_vault in the `rappid.json` record; the string is **never re-versioned**.
- **v2 + bare-Eternity + UUID = legacy**: read forever → canonicalize → emit Eternity (never emitted as identity again).
- `door_address.py` parses **both** forms (pure; `kind` supplied from the record for the Eternity form). +regression test, all green.

Sites: `Rappid.md` (canonical spec), `CONSTITUTION Art. XXXIV.1`, `ESTATE_SPEC`, `door_address.py`. Next phases: emit code → migrate the ~18 deployed doors → propagate ecosystem-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)