### PR TITLE
Phase C (kernel): mint Eternity rappids, not v2

### DIFF
--- a/specs/skill.md
+++ b/specs/skill.md
@@ -31,8 +31,8 @@ curl -fsSL https://kody-w.github.io/RAPP/installer/install.sh | bash
 ```python
 import hashlib
 owner_repo = "your-handle/your-handle-twin"
-hex32 = hashlib.blake2b(owner_repo.encode(), digest_size=16).hexdigest()
-rappid = f"rappid:v2:operator:@{owner_repo}:{hex32}@github.com/{owner_repo}"
+h = hashlib.sha256(owner_repo.encode()).hexdigest()  # full 256-bit SHA-256
+rappid = f"rappid:@{owner_repo}:{h}"  # Eternity: self-locating; kind ('operator') lives in the rappid.json record
 print(rappid)
 ```
 

--- a/tools/backfill_seeds.py
+++ b/tools/backfill_seeds.py
@@ -144,13 +144,16 @@ def _put_file(owner: str, repo: str, path: str, content_bytes: bytes,
     return False, f"PUT failed: {err.strip()[:160]}"
 
 
-def _canonical_rappid(owner: str, repo: str, kind: str) -> str:
-    """Mint the canonical rappid for an (owner, repo, kind).
+def _canonical_rappid(owner: str, repo: str, kind: str = None) -> str:
+    """Mint the canonical self-locating Eternity rappid for an (owner, repo).
 
-    Per SPEC §2.3: hex = BLAKE2b(owner/repo, 16).hexdigest() — deterministic.
+    `rappid:@<owner>/<slug>:<64hex>` per CONSTITUTION Art. XXXIV.1 (Eternity, 2026-06-03):
+    owner/repo locate the door; the **full 256-bit SHA-256** of `<owner>/<repo>` is the
+    (keyless, conventional) identity hash; `kind` is NOT in the string — it lives in the
+    door's rappid.json record. `kind` is accepted for caller compatibility and ignored here.
     """
-    hex32 = hashlib.blake2b(f"{owner}/{repo}".encode(), digest_size=16).hexdigest()
-    return f"rappid:v2:{kind}:@{owner}/{repo}:{hex32}@github.com/{owner}/{repo}"
+    h = hashlib.sha256(f"{owner}/{repo}".encode()).hexdigest()  # 64 hex, full 256-bit
+    return f"rappid:@{owner}/{repo}:{h}"
 
 
 def _build_rappid_json(rappid: str, owner: str, repo: str, kind: str,


### PR DESCRIPTION
The kernel mint helper (`tools/backfill_seeds._canonical_rappid`) + the operator example in `specs/skill.md` now emit the canonical self-locating Eternity form `rappid:@<owner>/<slug>:<64hex>` (full 256-bit SHA-256, kind in the record) instead of the v2 blake2b-128 string. Going-forward minting; no live-identity change.

Part of the v2→Eternity migration (standard locked in #48). Remaining: the example/RAR planters, the deployed-door re-anchor (graph-aware), and ecosystem doc propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)