### PR TITLE
Consolidate the rappid to one self-locating Eternity form (rappid:@owner/slug:64hex)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -2353,15 +2353,16 @@ platform globally, until the end of time.
 ### XXXIV.1 — Rappid is stamped at birth
 
 When a brainstem boots for the first time on a machine, it writes
-`~/.brainstem/rappid.json`. The schema is `rapp-rappid/2.0`; the
-`rappid` field carries the unified v2-format string described in the
-canonical spec at `pages/vault/Architecture/Rappid.md`:
+`~/.brainstem/rappid.json`. The `rappid` field carries the **consolidated**
+rappid string described in the canonical spec at
+`pages/vault/Architecture/Rappid.md`:
 
 ```json
 {
   "schema": "rapp-rappid/2.0",
-  "rappid": "rappid:v2:<kind>:@<publisher>/<slug>:<hash>@<home_vault_url>",
-  "parent_rappid": "<rappid in v2 format of the master that birthed this org>",
+  "rappid": "rappid:@<owner>/<slug>:<64hex>",
+  "kind": "<organism kind — door_type derives from this; see Art. XLVI.2>",
+  "parent_rappid": "rappid:@<owner>/<slug>:<64hex>",
   "parent_repo": "https://github.com/kody-w/RAPP",
   "parent_commit": "<git SHA at birth>",
   "born_at": "<ISO timestamp>",
@@ -2369,25 +2370,19 @@ canonical spec at `pages/vault/Architecture/Rappid.md`:
 }
 ```
 
-**Eternity amendment (locked 2026-06-01, self-locating refinement finalized
-2026-06-03) — supersedes the 2026-04-30 v2 format.** The canonical rappid is the
-**self-locating Eternity form** `rappid:@<owner>/<slug>:<64hex>`: an `@<owner>/<slug>`
-locator (the door is at `github.com/<owner>/<slug>` — preserves Article XLVI zero-lookup
-discovery) and the **full 256-bit SHA-256** identity hash (never truncated). The hash is
-the identity and the join key. **The string is never re-versioned** — all other structure
-(`kind`→`door_type`, ownership keypair, succession, attestation, `parent_rappid`,
-`home_vault`) lives in the `rappid.json` record as additive, versionless fields. Canonical
-spec: `pages/vault/Architecture/Rappid.md`; reference implementation: `kody-w/rapp-egg-hub`
-SPEC §2. The species tree is one tree, one identifier traverses it, and that identifier is
-the self-locating Eternity rappid.
-
-**Compatibility (the v2 form is now legacy).** The 2026-04-30 v2 unified format
-(`rappid:v2:<kind>:@<owner>/<slug>:<32hex>@<host>`) and the brief draft `1.1` bare-UUID form
-are **legacy forms**: read forever, canonicalize to Eternity (extract `@<owner>/<slug>`;
-recompute the 64-hex hash from the master pubkey, else re-anchor with the old string in
-`_migrated_from`), but **no longer emitted**. No rappid is lost (the species root's
-`0b635450-c042-49fb-b4b1-bdb571044dec` canonicalizes losslessly). **No future article shall
-introduce a parallel *identity* format**; the record carries new richness, never the string.
+**Format consolidation (locked 2026-06-03).** There is exactly one rappid
+format: `rappid:@<owner>/<slug>:<64hex>` — one string that is both the
+256-bit identity (the hash is the join key) and self-locating
+(`@<owner>/<slug>` → the door, no lookup). It consolidates the three prior
+forms into one: the draft v1 bare-UUID, the v2-structured
+`rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/...`, and the bare-Eternity
+`rappid:<slug>:<64hex>`. **`kind` and all structure live in the record**, never
+the string; **the string is never re-versioned** (new richness is an additive
+record field). Every legacy form is **read forever** and canonicalized
+(`tools/door_address.py::canonicalize_rappid`) — no rappid is lost (the species
+root's `0b635450-c042-49fb-b4b1-bdb571044dec` canonicalizes losslessly). **No
+future article shall introduce a parallel identity format.** The species tree is
+one tree, and one identifier system traverses it.
 
 The rappid is **never regenerated**. It is the organism's permanent
 identity. Backing up the org to a new repo, hatching, reverting,

--- a/pages/docs/ESTATE_SPEC.md
+++ b/pages/docs/ESTATE_SPEC.md
@@ -12,24 +12,21 @@ If you are writing a planter, an estate agent, a federation walker, a holocard r
 
 ## 1. The rappid IS the URL
 
-> **Eternity amendment (2026-06-03).** The canonical rappid is the **self-locating Eternity form** `rappid:@<owner>/<slug>:<64hex>` (CONSTITUTION Art. XXXIV.1 / `pages/vault/Architecture/Rappid.md`). It keeps the zero-lookup discovery property below — `owner`/`repo` parse straight out of the `@<owner>/<slug>` locator — while the identity is the full 256-bit hash and `kind` (→ `door_type`) is read from the door's `rappid.json` record. The v2 form below is the **legacy door-addressing form**: read-compatible, no longer emitted. `door_from_rappid()` reads both; for the Eternity form it derives every URL from `@<owner>/<slug>` and takes `kind` from `rappid.json::kind`.
-
-The legacy v2 rappid addressing format:
+The **consolidated** rappid format (locked 2026-06-03):
 
 ```
-rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner>/<repo>
+rappid:@<owner>/<slug>:<64hex>
 ```
 
-The `<owner>/<repo>` segment appears **twice** by design — first as the abbreviated identity reference, then as the full origin pin. Both MUST be the same string. A rappid where they disagree is invalid and MUST be rejected (Article XLVI.5).
-
-From this string alone, by **string parsing** (not lookup, not config, not env), you derive:
+`@<owner>/<slug>` is the **location** — `github.com/<owner>/<slug>` is the door. From this string alone, by **string parsing** (not lookup, not config, not env), you derive every door URL in §2:
 
 | Field | How |
 |---|---|
-| `kind` | The token between `rappid:v2:` and `:@` |
-| `owner` | Everything after `@` and before `/` in the first segment |
-| `repo` | Everything after `/` and before `:` in the first segment |
-| `door_type` | `"front_door"` if `kind` ∈ `_FRONT_DOOR_KINDS` (`twin`, `operator`, … — the full set is the **Valid kinds** row below), else `"gate"` (XLVI.2) |
+| `owner` | Everything after `@` and before `/` |
+| `repo` (`slug`) | Everything after `/` and before the final `:` |
+| `hash` | The 64-hex after the final `:` — the 256-bit identity / join key |
+
+`kind` (→ `door_type`) is **no longer in the string** — it lives in the door's `rappid.json` record (fetch the `identity` URL in §2). The pure-string `door_from_rappid()` returns the URLs (location) for any door; `kind`/`door_type` come from the record (or, for a legacy v2 string, are read inline). Legacy forms — v2 `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>` and bare UUIDs — are read-compatible via `door_address.py` (`canonicalize_rappid`).
 
 **Valid kinds** (frozen as of 2026-05-09; **amended 2026-06-02** per CONSTITUTION Art. XLVI.2 to ratify the single-presence kinds already shipped across the kernel, RAR, and RAPP-Network): single AI presences → `front_door`: `twin`, `operator`, `personal`, `project`, `memorial`, `pre-founder`, `mirror`, `experiment`, `custom`; community spaces you enter → `gate`: `neighborhood`, `ant-farm`, `braintrust`, `workspace`, `hatched`, `rapplication`, `prototype`, `place`. Adding a new kind requires a CONSTITUTION amendment because every consumer derives behavior from this token; the canonical machine-readable set is `VALID_KINDS` / `_FRONT_DOOR_KINDS` in `tools/door_address.py` (the one parser consumers MUST import).
 

--- a/pages/vault/Architecture/Rappid.md
+++ b/pages/vault/Architecture/Rappid.md
@@ -26,32 +26,21 @@ Think of a rappid as the species' social-security number. Universal. Singular. T
 
 ## The format (one format, forever)
 
-> **AMENDMENT — the Eternity standard, self-locating refinement (locked 2026-06-01, finalized 2026-06-03). This is THE canonical rappid; everything below it is legacy.**
->
-> ```
-> rappid:@<owner>/<slug>:<64hex>
-> ```
->
-> - `@<owner>/<slug>` — **locator + namespace**. `<slug>` is the immutable birth name (gene name); `<owner>` is the publishing handle. The pair makes the rappid **self-locating**: the door lives at `github.com/<owner>/<slug>`, served at `<owner>.github.io/<slug>`, identity at `raw.githubusercontent.com/<owner>/<slug>/main/rappid.json` — all derivable from the string with **zero lookup** (preserves Article XLVI / ESTATE_SPEC discovery).
-> - `<64hex>` — the **full 256-bit SHA-256** identity hash, **never truncated to 128**. The hash is the identity and the **join key**: matching/dedup is ALWAYS on the hash.
-> - **Everything else lives in the `rappid.json` record** as additive, versionless fields: `kind` (→ `door_type`), `pubkey`, `sig_suite`, `birth_attestation`, `key_succession`, `registry_anchor`, `parent_rappid`, and `home_vault` (a non-GitHub canonical home, when not the default `github.com/<owner>/<slug>`). **The string is never re-versioned** — that was the v2/v3 mistake.
-> - Reference implementation: `kody-w/rapp-egg-hub` SPEC §2.
->
-> **Compatibility contract:** consumers **read every legacy form forever** and **emit only** the canonical Eternity string. Legacy forms and how they canonicalize:
-> - **v2** `rappid:v2:<kind>:@<owner>/<slug>:<32hex>@<host>` — take `@<owner>/<slug>`; `kind`/`host` move to the record; the 32-hex hash is recomputed to the full 64-hex from the master pubkey (`sha256(pubkey_SPKI)`) when present, else the door is re-anchored once (old string preserved in `_migrated_from`).
-> - **bare Eternity** `rappid:<slug>:<64hex>` — prepend `@<owner>/` from the record.
-> - **bare UUID** (draft v1) — genesis re-anchor; the UUID is preserved in `_migrated_from`.
->
-> The v2-structured form below is the legacy door-addressing form (ratified 2026-04-30): read-compatible, **no longer emitted**.
+```
+rappid:@<owner>/<slug>:<64hex>
+```
+
+The **consolidated** rappid (locked 2026-06-03) — one string that is **both identity and self-locating**, unifying the three prior forms (v1 bare-UUID, v2-structured, bare-Eternity) into one:
 
 | Field | Meaning |
 |---|---|
 | `rappid:` | Always literal. Identifies this string as a rappid. |
-| `v2` | Format version. v2 is the unified format ratified 2026-04-30. There was a draft v1 (UUID-only) era; v2 supersedes it. |
-| `<kind>` | What kind of organism this is. Open, **amendment-gated** enumeration spanning the recursive species tree (scale axis: `prototype`, `kernel-variant`, `organism`, `twin`, `swarm`, `rapplication`, `agent`) plus identity kinds (`personal`, `operator`, `project`, …). The **door-bearing** subset — kinds that resolve to a door address + `door_type` — is frozen canonically in CONSTITUTION Art. XLVI.2 / `tools/door_address.py` (`VALID_KINDS`); code-only kinds (`kernel-variant`, `organism`, `swarm`, `agent`) carry a kind but no door. `operator` is in active use for Article-XLVI front doors (e.g. `kody-w-twin`) — see [[The Federated Twin Egg Hatcher Pattern]]. New kinds are added as the species evolves (e.g. `android`, `cloud`, `embodied`) via the Art. XLVI.2 amendment process when door-bearing. |
-| `@<publisher>/<slug>` | Namespace. Publisher is the owning brand/entity; slug is the entity name within that publisher. Like a Docker image path. |
-| `<hash>` | Stable, immutable identifier. For organisms with cryptographic identity (master keypair): `sha256(master_pubkey_SPKI)[:32]`. For organisms without keypairs (the species root, code variants without keys): a unique stable identifier (UUID-derived or commit-derived). |
-| `@<home_vault_url>` | Where the canonical signed records live (or, for code-only organisms, where the repo lives). Network-resolvable. **A discovery hint, not a binding** — per [[Local-First-by-Design]], local copies are authoritative; hosts are transports. |
+| `@<owner>/<slug>` | The **location**: `github.com/<owner>/<slug>` is the door/repo. Every door URL derives from this by **string parsing — no lookup, no API** (CONSTITUTION Art. XLVI). `<slug>` is the immutable birth name (the gene name / routing hint). |
+| `<64hex>` | The full **256-bit SHA-256** identity hash — `sha256(master_pubkey_SPKI)`, **never truncated to 128**. The hash IS the identity and the **join key**: matching/dedup is always on the hash, never the slug. Keyless organisms (the species root, code variants) use a stable hash (UUID/commit-derived), re-anchored to 256-bit when minted fresh. |
+
+**`kind` and all other structure live in the `rappid.json` RECORD, not the string.** `kind` → `door_type` per CONSTITUTION Art. XLVI.2 (`VALID_KINDS` in `tools/door_address.py`); ownership keypair (`pubkey`/`sig_suite`), `birth_attestation`, `key_succession`, `registry_anchor` are additive, versionless record fields. **The string is never re-versioned** — new richness goes in the record (that was the v2/v3 mistake).
+
+**Legacy forms — read forever, emit only the consolidated form.** v1 bare-UUID, v2 `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`, and bare-Eternity `rappid:<slug>:<64hex>` are all READ and `canonicalize_rappid()`'d to the form above. `tools/door_address.py` is the one parser; consumers MUST import it.
 
 ### Concrete examples
 

--- a/tests/test_door_address.py
+++ b/tests/test_door_address.py
@@ -1,56 +1,129 @@
-"""Tests for tools/door_address.py — the one rappid → door parser.
+"""Tests for the consolidated rappid (`rappid:@<owner>/<slug>:<64hex>`) parser.
 
-Covers the canonical self-locating Eternity form `rappid:@<owner>/<slug>:<64hex>`
-(CONSTITUTION Art. XXXIV.1) and the legacy v2 form (read-compatible).
+    python3 -m pytest tests/test_door_address.py -v
+
+Covers: canonical parse + door URLs, reading every legacy form (v2, bare UUID),
+canonicalization (idempotent; v2 → canonical preserves the hash), invalid-form
+rejection, kind/door_type sourcing, and the back-compat consumer API.
 """
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
-import door_address as d  # noqa: E402
+import pytest
 
-H64 = "a" * 64
-H32 = "b" * 32
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import door_address as da  # noqa: E402
+
+H64 = "15461d6259ec49bdaf8ea032571b3f0315461d6259ec49bdaf8ea032571b3f03"  # 64 hex
+H32 = "15461d6259ec49bdaf8ea032571b3f03"                                  # 32 hex (legacy v2)
+CANON = f"rappid:@kody-w/echo-brainstem:{H64}"
 V2 = f"rappid:v2:twin:@kody-w/echo-brainstem:{H32}@github.com/kody-w/echo-brainstem"
+UUID = "915f54e5-4c71-4de9-bba3-6604461d05e5"
 
 
-def test_eternity_canonical_with_kind():
-    e = d.door_from_rappid(f"rappid:@kody-w/echo-brainstem:{H64}", kind="twin")
-    assert e["owner"] == "kody-w" and e["repo"] == "echo-brainstem"
-    assert e["kind"] == "twin" and e["door_type"] == "front_door"
-    assert e["urls"]["identity"] == "https://raw.githubusercontent.com/kody-w/echo-brainstem/main/rappid.json"
-    assert e["urls"]["front"] == "https://kody-w.github.io/echo-brainstem/"
+# ── parse ─────────────────────────────────────────────────────────────────────
+def test_parse_canonical():
+    p = da.parse_rappid(CANON)
+    assert p == {"form": "canonical", "owner": "kody-w", "slug": "echo-brainstem",
+                 "hash": H64, "hash_bits": 256, "kind": None}
 
 
-def test_eternity_without_kind_still_self_locates():
-    e = d.door_from_rappid(f"rappid:@kody-w/echo-brainstem:{H64}")
-    assert e["kind"] is None and e["door_type"] is None
-    assert e["urls"]["repo"] == "https://github.com/kody-w/echo-brainstem"
+def test_parse_v2_legacy():
+    p = da.parse_rappid(V2)
+    assert p["form"] == "v2-legacy"
+    assert p["owner"] == "kody-w" and p["slug"] == "echo-brainstem"
+    assert p["hash"] == H32 and p["hash_bits"] == 128 and p["kind"] == "twin"
 
 
-def test_legacy_v2_unchanged():
-    l = d.door_from_rappid(V2)
-    assert l["owner"] == "kody-w" and l["kind"] == "twin" and l["door_type"] == "front_door"
+def test_parse_uuid_legacy_has_no_location():
+    p = da.parse_rappid(UUID)
+    assert p["form"] == "uuid-legacy"
+    assert p["owner"] is None and p["slug"] is None
+    assert p["hash"] == UUID.replace("-", "")
 
 
-def test_owner_repo_from_both_forms():
-    assert d.owner_repo_from_rappid(f"rappid:@kody-w/x:{H64}") == ("kody-w", "x")
-    assert d.owner_repo_from_rappid(V2) == ("kody-w", "echo-brainstem")
+def test_parse_v2_origin_mismatch_rejected():
+    bad = f"rappid:v2:twin:@kody-w/echo-brainstem:{H32}@github.com/kody-w/OTHER"
+    with pytest.raises(da.InvalidRappidError):
+        da.parse_rappid(bad)
 
 
-def test_invalid_forms_raise():
-    for bad in ["nonsense", f"rappid:@kody-w/x:{H32}",  # 32-hex is too short for Eternity
-                f"rappid:v2:twin:@a/b:{H32}@github.com/a/c"]:  # v2 origin mismatch
-        try:
-            d.door_from_rappid(bad)
-            assert False, f"should have raised for {bad!r}"
-        except d.InvalidRappidError:
-            pass
+@pytest.mark.parametrize("bad", ["", "nope", "rappid:@kody-w:abc", f"rappid:@k/s:{H64}x",
+                                 "rappid:@kody-w/echo:xyz", 123])
+def test_parse_invalid_rejected(bad):
+    with pytest.raises(da.InvalidRappidError):
+        da.parse_rappid(bad)
 
 
-def test_unknown_kind_rejected():
-    try:
-        d.door_from_rappid(f"rappid:@a/b:{H64}", kind="bogus")
-        assert False, "bogus kind should raise"
-    except d.InvalidRappidError:
-        pass
+# ── canonicalize ────────────────────────────────────────────────────────────────
+def test_canonicalize_idempotent():
+    assert da.canonicalize_rappid(CANON) == CANON
+
+
+def test_canonicalize_v2_drops_decorations_keeps_hash():
+    # v2 → consolidated structure, hash preserved (no re-anchor here)
+    assert da.canonicalize_rappid(V2) == f"rappid:@kody-w/echo-brainstem:{H32}"
+
+
+def test_canonicalize_uuid_needs_location():
+    with pytest.raises(da.InvalidRappidError):
+        da.canonicalize_rappid(UUID)  # bare UUID carries no owner/slug
+    assert da.canonicalize_rappid(UUID, owner="kody-w", slug="heimdall") == \
+        f"rappid:@kody-w/heimdall:{UUID.replace('-', '')}"
+
+
+# ── door_from_rappid: self-location + URLs ──────────────────────────────────────
+def test_door_urls_from_canonical():
+    d = da.door_from_rappid(CANON)
+    assert d["owner"] == "kody-w" and d["repo"] == "echo-brainstem"
+    assert d["urls"]["repo"] == "https://github.com/kody-w/echo-brainstem"
+    assert d["urls"]["front"] == "https://kody-w.github.io/echo-brainstem/"
+    assert d["urls"]["identity"] == \
+        "https://raw.githubusercontent.com/kody-w/echo-brainstem/main/rappid.json"
+    assert d["canonical"] == CANON
+
+
+def test_door_urls_identical_across_canonical_and_v2():
+    # The whole point: a v2 door and its consolidated form resolve to the SAME door.
+    assert da.door_from_rappid(CANON)["urls"] == da.door_from_rappid(V2)["urls"]
+
+
+def test_kind_and_door_type_from_v2_string():
+    d = da.door_from_rappid(V2)
+    assert d["kind"] == "twin" and d["door_type"] == "front_door"
+
+
+def test_kind_from_record_arg_for_canonical():
+    assert da.door_from_rappid(CANON)["kind"] is None          # not in the string
+    assert da.door_from_rappid(CANON)["door_type"] is None
+    d = da.door_from_rappid(CANON, kind="neighborhood")        # supplied from the record
+    assert d["kind"] == "neighborhood" and d["door_type"] == "gate"
+
+
+def test_invalid_kind_rejected():
+    with pytest.raises(da.InvalidRappidError):
+        da.door_from_rappid(CANON, kind="not-a-kind")
+
+
+def test_bare_uuid_door_raises_without_location():
+    with pytest.raises(da.InvalidRappidError):
+        da.door_from_rappid(UUID)
+
+
+# ── back-compat consumer API (rebuild_estate etc. rely on these) ────────────────
+def test_owner_repo_helper():
+    assert da.owner_repo_from_rappid(CANON) == ("kody-w", "echo-brainstem")
+    assert da.owner_repo_from_rappid(V2) == ("kody-w", "echo-brainstem")
+
+
+def test_door_dict_has_back_compat_keys():
+    d = da.door_from_rappid(V2)
+    for k in ("rappid", "owner", "repo", "kind", "door_type", "urls"):
+        assert k in d, f"consumers rely on door['{k}']"
+
+
+def test_estate_url():
+    assert da.estate_url("kody-w") == \
+        "https://raw.githubusercontent.com/kody-w/rapp-estate/main/estate.json"
+    with pytest.raises(da.InvalidRappidError):
+        da.estate_url("bad/handle")

--- a/tools/door_address.py
+++ b/tools/door_address.py
@@ -1,65 +1,73 @@
 """door_address — pure derivation of a door's canonical URL set from its rappid.
 
-Authority: pages/docs/ESTATE_SPEC.md (CONSTITUTION Article XLVI).
-
-Canonical form: the self-locating Eternity rappid `rappid:@<owner>/<slug>:<64hex>`
-(CONSTITUTION Art. XXXIV.1, finalized 2026-06-03) — owner/slug locate the door, the
-256-bit hash is the identity, and `kind` lives in the door's rappid.json record.
-The legacy v2 form (`rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`)
-is read-compatible per the compatibility contract (read every legacy form, emit Eternity).
+Authority: pages/docs/ESTATE_SPEC.md (CONSTITUTION Article XLVI + XXXIV.1).
 
 This is the SINGLE implementation of the Estate Spec's `door_from_rappid()`
 contract (ESTATE_SPEC §5). Every consumer that maps rappid → door URLs uses
 this module — never reinvents the parsing, never patches around it.
 
-Per Article XLVI.5 (No Fallbacks; Spec Says What's True): an invalid rappid
-raises InvalidRappidError. There is no "best-effort" mode, no `local.github.io`
-workaround, no "guess the kind from the name." The string either matches the
-spec or it doesn't.
+THE CONSOLIDATED RAPPID (the one format, locked 2026-06-03)
+----------------------------------------------------------
+    rappid:@<owner>/<slug>:<64hex>
+
+One string that is BOTH identity and self-locating:
+  - `@<owner>/<slug>` — the canonical location. `github.com/<owner>/<slug>` is
+    the door; every door URL derives from it by string parsing (no lookup, no
+    API), preserving the Article-XLVI curl-discovery property.
+  - `<64hex>` — the full 256-bit SHA-256 identity hash. The hash is the identity
+    and the JOIN KEY; matching/dedup is always on the hash, never the slug.
+  - `kind` and all other structure live in the `rappid.json` RECORD (fetched
+    from the located repo), not the string — per the Eternity standard.
+
+The string is NEVER re-versioned. This consolidates the three prior forms:
+  - v1  `<uuid>`                                              (bare UUID — not self-locating)
+  - v2  `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`
+  - the bare-Eternity `rappid:<slug>:<64hex>`                 (not self-locating)
+into the one self-locating Eternity form above.
+
+COMPATIBILITY: every legacy form is READ FOREVER and canonicalized
+(`canonicalize_rappid`); only the consolidated form is emitted. A consumer
+holding a legacy rappid still resolves; door_from_rappid returns `kind`/
+`door_type` from the legacy v2 string when present, or from a record-supplied
+`kind` for the consolidated form, else None (resolve kind from the record).
 
 Pure stdlib. Zero deps. Importable from agents/, tools/, tests/, or anywhere.
 """
-
 from __future__ import annotations
 
 import re
 
+_NAME = r"[A-Za-z0-9][A-Za-z0-9._-]*"
 
-# Canonical: the self-locating Eternity rappid (CONSTITUTION Art. XXXIV.1, 2026-06-03).
-# rappid:@<owner>/<slug>:<64hex> — owner/slug locate the door; the 256-bit hash is the
-# identity; `kind` is NOT in the string (it lives in the rappid.json record and is passed
-# to door_from_rappid). 64 lowercase hex = full SHA-256, never the truncated 32.
-_ETERNITY_RE = re.compile(
-    r"^rappid:@(?P<owner>[A-Za-z0-9][A-Za-z0-9._-]*)/(?P<slug>[A-Za-z0-9][A-Za-z0-9._-]*):"
-    r"(?P<hex>[a-f0-9]{64})$"
+# Consolidated canonical form: rappid:@<owner>/<slug>:<64hex>
+_CANON_RE = re.compile(
+    rf"^rappid:@(?P<owner>{_NAME})/(?P<slug>{_NAME}):(?P<hash>[a-f0-9]{{64}})$"
+)
+# Legacy v2 (read-only): rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>
+_V2_RE = re.compile(
+    rf"^rappid:v2:(?P<kind>[a-z][a-z0-9-]*):"
+    rf"@(?P<owner>{_NAME})/(?P<repo>{_NAME}):(?P<hash>[a-f0-9]{{32}})"
+    rf"@github\.com/(?P<owner2>{_NAME})/(?P<repo2>{_NAME})$"
+)
+# Legacy v1 (read-only): a bare UUID. Carries NO location — callers must supply
+# the repo (owner/slug) out of band to build URLs or canonicalize.
+_UUID_RE = re.compile(
+    r"^(?P<hash>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+)
+# Grandfathered canonical structure: a legacy hash (e.g. a migrated v2 32-hex not
+# yet re-anchored to 256-bit) carried in the new self-locating structure. Checked
+# LAST so a real 64-hex always matches _CANON_RE first.
+_CANON_LEGACYHASH_RE = re.compile(
+    rf"^rappid:@(?P<owner>{_NAME})/(?P<slug>{_NAME}):(?P<hash>[a-f0-9]{{8,}})$"
 )
 
-# Legacy v2 rappid addressing regex — read-compatible, no longer emitted.
-# rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner2>/<repo2>
-# Where (owner, repo) MUST equal (owner2, repo2) — that equality is checked
-# explicitly below because regex backreferences make the pattern unreadable.
-_RAPPID_RE = re.compile(
-    r"^rappid:v2:"
-    r"(?P<kind>[a-z][a-z0-9-]*):"
-    r"@(?P<owner>[A-Za-z0-9][A-Za-z0-9._-]*)/(?P<repo>[A-Za-z0-9][A-Za-z0-9._-]*):"
-    r"(?P<hex>[a-f0-9]{32})"
-    r"@github\.com/(?P<owner2>[A-Za-z0-9][A-Za-z0-9._-]*)/(?P<repo2>[A-Za-z0-9][A-Za-z0-9._-]*)$"
-)
 
-
-# Per ESTATE_SPEC §1: valid kinds are frozen as of 2026-05-09. Adding a kind
-# requires a CONSTITUTION amendment because every consumer derives behavior
-# from this token.
-# Front-door kinds: a single AI presence. Extended 2026-06-02 (CONSTITUTION
-# Art. XLVI.2 amendment) to ratify the single-presence kinds already emitted
-# across the kernel (TWIN_LIFECYCLE_SPEC, NEIGHBORHOOD_EGG_SPEC, ECOSYSTEM),
-# RAR `@rapp/twin_agent`, and RAPP-Network's `project_twin_agent.py`.
+# Front-door kinds: a single AI presence (CONSTITUTION Art. XLVI.2). `place` is a
+# gate (a location others enter). Extended 2026-06-02; place reclassified 2026-06-03.
 _FRONT_DOOR_KINDS = frozenset({
     "twin", "operator", "personal", "project", "memorial",
     "pre-founder", "mirror", "experiment", "custom",
 })
-# Gate kinds: a community AI you enter to find others. `place` is a gate — a
-# location others enter, not a single presence (reclassified 2026-06-03).
 _GATE_KINDS = frozenset({
     "neighborhood", "ant-farm", "braintrust", "workspace",
     "hatched", "rapplication", "prototype", "place",
@@ -67,35 +75,124 @@ _GATE_KINDS = frozenset({
 VALID_KINDS = _FRONT_DOOR_KINDS | _GATE_KINDS
 
 
-# Per ESTATE_SPEC §2 / CONSTITUTION Art. XLVI.2: door type is deterministic
-# from kind. A single AI presence is a front door; a community AI you enter to
-# find others is a gate. The `operator` kind names a person's personal brainstem
-# identity, which functions as their own front door.
-def _door_type_for_kind(kind: str) -> str:
+def _door_type_for_kind(kind: str | None) -> str | None:
+    if kind is None:
+        return None
     return "front_door" if kind in _FRONT_DOOR_KINDS else "gate"
 
 
 class InvalidRappidError(ValueError):
-    """Raised by door_from_rappid for any rappid that doesn't match the spec.
+    """Raised for a rappid that matches no known form (consolidated or legacy)."""
 
-    Subclasses ValueError so callers can `except ValueError` if they want a
-    catch-all, but typed for explicit handling per ESTATE_SPEC §6 (stale
-    rappid rejection).
+
+def parse_rappid(rappid: str) -> dict:
+    """Parse any rappid form. Returns a dict:
+
+      {form, owner, slug, hash, hash_bits, kind}
+
+    - form: "canonical" | "canonical-legacyhash" | "v2-legacy" | "uuid-legacy"
+    - owner/slug: the location (None for a bare UUID, which is not self-locating)
+    - hash: the identity hash (hex, dashes stripped for UUIDs)
+    - hash_bits: 256 for a full 64-hex, else the legacy bit-width (128 for v2/UUID)
+    - kind: present only for v2-legacy (it carried kind inline); else None
+
+    Reads every legacy form forever. Raises InvalidRappidError on no match.
     """
+    if not isinstance(rappid, str):
+        raise InvalidRappidError(f"rappid must be a string, got {type(rappid).__name__}")
+
+    m = _CANON_RE.match(rappid)
+    if m:
+        return {"form": "canonical", "owner": m["owner"], "slug": m["slug"],
+                "hash": m["hash"], "hash_bits": 256, "kind": None}
+
+    m = _V2_RE.match(rappid)
+    if m:
+        if m["owner"] != m["owner2"] or m["repo"] != m["repo2"]:
+            raise InvalidRappidError(
+                f"v2 rappid origin mismatch: @{m['owner']}/{m['repo']} vs "
+                f"@github.com/{m['owner2']}/{m['repo2']} — the two MUST be equal.")
+        return {"form": "v2-legacy", "owner": m["owner"], "slug": m["repo"],
+                "hash": m["hash"], "hash_bits": 128, "kind": m["kind"]}
+
+    m = _UUID_RE.match(rappid)
+    if m:
+        return {"form": "uuid-legacy", "owner": None, "slug": None,
+                "hash": m["hash"].replace("-", ""), "hash_bits": 128, "kind": None}
+
+    m = _CANON_LEGACYHASH_RE.match(rappid)
+    if m:
+        return {"form": "canonical-legacyhash", "owner": m["owner"], "slug": m["slug"],
+                "hash": m["hash"], "hash_bits": len(m["hash"]) * 4, "kind": None}
+
+    raise InvalidRappidError(
+        f"rappid matches no known form: {rappid!r}. "
+        f"Canonical: rappid:@<owner>/<slug>:<64hex>")
 
 
-def _door_dict(rappid: str, owner: str, repo: str, kind: str | None) -> dict:
-    """Build the canonical door object from a located (owner, repo) and optional kind."""
-    raw_base = f"https://raw.githubusercontent.com/{owner}/{repo}/main"
+def canonicalize_rappid(rappid: str, owner: str | None = None, slug: str | None = None) -> str:
+    """Return the consolidated canonical string for any rappid form.
+
+    Restructures into `rappid:@<owner>/<slug>:<hash>`, PRESERVING the hash (the
+    identity). A v2 string drops its `v2:`/`<kind>`/`@host` decorations; a bare
+    UUID needs `owner`/`slug` supplied (it carries no location). Idempotent on an
+    already-canonical string. The one-time 128→256-bit re-anchor (minting a fresh
+    64-hex and recording the old id in `_migrated_from`) is a separate step — this
+    function never invents a hash.
+    """
+    p = parse_rappid(rappid)
+    o = p["owner"] or owner
+    s = p["slug"] or slug
+    if not o or not s:
+        raise InvalidRappidError(
+            f"cannot canonicalize {rappid!r}: it carries no location (bare UUID); "
+            f"supply owner=/slug= (the repo it lives in).")
+    return f"rappid:@{o}/{s}:{p['hash']}"
+
+
+def door_from_rappid(rappid: str, kind: str | None = None) -> dict:
+    """Return the canonical door object for a rappid. Pure function (no I/O).
+
+    Reads the consolidated form and every legacy form. The door's URLs derive
+    purely from the self-locating `@<owner>/<slug>` (or a v2 string's owner/repo).
+
+    `kind`/`door_type`: taken from the v2-legacy string when present, else from
+    the `kind` argument (which a caller resolves from the fetched `rappid.json`
+    record for the consolidated form), else None.
+
+    Returns: {rappid, canonical, owner, repo, slug, hash, kind, door_type, urls, form}
+
+    Raises InvalidRappidError if the string matches no form, or carries no
+    location (a bare UUID — supply owner/slug via canonicalize first), or if a
+    provided/parsed kind is not in VALID_KINDS.
+    """
+    p = parse_rappid(rappid)
+    if not p["owner"] or not p["slug"]:
+        raise InvalidRappidError(
+            f"rappid {rappid!r} is a bare UUID (no location). Canonicalize it with "
+            f"owner=/slug= before resolving a door.")
+
+    owner, slug = p["owner"], p["slug"]
+    resolved_kind = p["kind"] if p["kind"] is not None else kind
+    if resolved_kind is not None and resolved_kind not in VALID_KINDS:
+        raise InvalidRappidError(
+            f"rappid kind {resolved_kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
+            f"Adding a kind requires a CONSTITUTION amendment (Article XLVI.2).")
+
+    raw_base = f"https://raw.githubusercontent.com/{owner}/{slug}/main"
     return {
         "rappid": rappid,
+        "canonical": f"rappid:@{owner}/{slug}:{p['hash']}",
         "owner": owner,
-        "repo": repo,
-        "kind": kind,
-        "door_type": _door_type_for_kind(kind) if kind else None,
+        "repo": slug,   # back-compat alias; slug IS the repo for a door
+        "slug": slug,
+        "hash": p["hash"],
+        "kind": resolved_kind,
+        "door_type": _door_type_for_kind(resolved_kind),
+        "form": p["form"],
         "urls": {
-            "repo":      f"https://github.com/{owner}/{repo}",
-            "front":     f"https://{owner}.github.io/{repo}/",
+            "repo":      f"https://github.com/{owner}/{slug}",
+            "front":     f"https://{owner}.github.io/{slug}/",
             "identity":  f"{raw_base}/rappid.json",
             "holocard":  f"{raw_base}/card.json",
             "holo_md":   f"{raw_base}/holo.md",
@@ -105,67 +202,6 @@ def _door_dict(rappid: str, owner: str, repo: str, kind: str | None) -> dict:
             "facets":    f"{raw_base}/facets.json",
         },
     }
-
-
-def door_from_rappid(rappid: str, kind: str | None = None) -> dict:
-    """Return the canonical door object for a rappid. Pure function.
-
-    Implements the contract in ESTATE_SPEC §5. Accepts the **canonical self-locating
-    Eternity** rappid `rappid:@<owner>/<slug>:<64hex>` and the **legacy v2** form
-    `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`.
-
-    Args:
-      rappid: the rappid string (Eternity canonical, or legacy v2).
-      kind: the organism kind, read from the door's rappid.json record. Used only for the
-        Eternity form (whose string carries no kind); ignored for v2 (kind parsed from the
-        string). If omitted for an Eternity rappid, `kind` and `door_type` come back None.
-
-    Returns:
-      A dict with keys: rappid, owner, repo, kind, door_type, urls. `urls` has keys:
-      repo, front, identity, holocard, holo_md, avatar, summon_qr, members, facets. The
-      `members` URL is populated only for gates; twins return an empty members.json (or 404).
-
-    Raises:
-      InvalidRappidError: if the string matches neither the canonical Eternity form nor the
-        legacy v2 form; if a v2 rappid's left (owner, repo) != its origin pin; or if a
-        supplied kind is not in VALID_KINDS.
-    """
-    if not isinstance(rappid, str):
-        raise InvalidRappidError(f"rappid must be a string, got {type(rappid).__name__}")
-
-    # Canonical: the self-locating Eternity form. owner/slug locate the door; kind (and
-    # thus door_type) comes from the record, supplied by the caller.
-    em = _ETERNITY_RE.match(rappid)
-    if em:
-        if kind is not None and kind not in VALID_KINDS:
-            raise InvalidRappidError(
-                f"rappid kind {kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
-                f"Adding a kind requires a CONSTITUTION amendment (Article XLVI)."
-            )
-        return _door_dict(rappid, em.group("owner"), em.group("slug"), kind)
-
-    # Legacy: the v2 addressing form. kind is parsed from the string.
-    m = _RAPPID_RE.match(rappid)
-    if not m:
-        raise InvalidRappidError(
-            f"rappid matches neither the canonical Eternity form "
-            f"(rappid:@<owner>/<slug>:<64hex>) nor the legacy v2 form: {rappid!r}"
-        )
-
-    owner = m.group("owner")
-    repo = m.group("repo")
-    if owner != m.group("owner2") or repo != m.group("repo2"):
-        raise InvalidRappidError(
-            f"rappid origin mismatch: identity says @{owner}/{repo}, origin pin says "
-            f"@github.com/{m.group('owner2')}/{m.group('repo2')}. The two MUST be equal."
-        )
-    v2_kind = m.group("kind")
-    if v2_kind not in VALID_KINDS:
-        raise InvalidRappidError(
-            f"rappid kind {v2_kind!r} is not in VALID_KINDS={sorted(VALID_KINDS)}. "
-            f"Adding a kind requires a CONSTITUTION amendment (Article XLVI)."
-        )
-    return _door_dict(rappid, owner, repo, v2_kind)
 
 
 def estate_url(github_handle: str) -> str:
@@ -178,9 +214,8 @@ def estate_url(github_handle: str) -> str:
     return f"https://raw.githubusercontent.com/{github_handle}/rapp-estate/main/estate.json"
 
 
-# Convenience: parse just the (owner, repo) without building the full URL set.
-# Used by the planter where it needs the pair but not the URLs.
 def owner_repo_from_rappid(rappid: str) -> tuple[str, str]:
-    """Return (owner, repo) for a valid rappid. Raises InvalidRappidError."""
+    """Return (owner, repo) for a self-locating rappid. Raises InvalidRappidError
+    for a bare UUID (no location)."""
     door = door_from_rappid(rappid)
     return door["owner"], door["repo"]


### PR DESCRIPTION
Locks the canonical rappid as **`rappid:@<owner>/<slug>:<64hex>`** — one string that is both the **256-bit identity** (hash = join key) and **self-locating** (`@owner/slug` → every door URL, no lookup; keeps Art. XLVI curl-discovery). Consolidates the three prior forms (v1 bare-UUID, v2-structured, bare-Eternity) into one; `kind`/structure live in the `rappid.json` record; the string is never re-versioned.

**`tools/door_address.py` rewritten** — `parse_rappid`/`canonicalize_rappid` read **every legacy form forever** and emit only the consolidated form; `door_from_rappid` keeps the back-compat dict. **22 new tests** (`tests/test_door_address.py`) green; consumers compile; the 28 pre-existing federation-test failures are unrelated. Specs updated: `Rappid.md`, `ESTATE_SPEC §1`, `CONSTITUTION Art. XXXIV.1`.

Next phase: migrate RAR + the ~18 deployed doors' `rappid.json` to the consolidated form (read-compatible meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)