### PR TITLE
Consolidate rappid: stop emitting/declaring/only-parsing the v2 form

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -30,34 +30,39 @@ That's it. Everything else (planting doors, joining gates, summoning twins) is o
 
 ---
 
-## §2 — Identity (the rappid, v2)
+## §2 — Identity (the rappid)
 
-A rappid is the door's globally-resolvable address. Canonical format:
+A rappid is the door's globally-resolvable address. Canonical format (the consolidated form, locked 2026-06-03):
 
 ```
-rappid:v2:<kind>:@<owner>/<repo>:<32-hex-no-dashes>@github.com/<owner>/<repo>
+rappid:@<owner>/<slug>:<64-hex-no-dashes>
 ```
 
-The `<owner>/<repo>` segment appears **twice by design**: first as the abbreviated identity reference, then as the origin pin. Both segments MUST be the same string — a rappid where they disagree is invalid and rejected.
+One string that is BOTH identity and self-locating:
+- `@<owner>/<slug>` — the canonical location; `github.com/<owner>/<slug>` is the door, and every door URL derives from it by string parsing alone (no lookup, no API).
+- `<64-hex>` — the full **256-bit** SHA-256 identity hash. The hash is the identity and the JOIN KEY; matching/dedup is always on the hash, never the slug.
+- `kind` and all other structure live in the door's `rappid.json` RECORD, **never in the string**.
+
+The string is NEVER re-versioned. It consolidates the three prior forms (a bare UUID; `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/<owner>/<repo>`; and the bare-Eternity `rappid:<slug>:<64hex>`) into this one self-locating Eternity form. Every legacy form is **read forever** and canonicalized; only the consolidated form is emitted. See `tools/door_address.py` (`parse_rappid` / `canonicalize_rappid`).
 
 ### §2.1 Valid kinds (frozen)
 
 `twin`, `neighborhood`, `ant-farm`, `braintrust`, `workspace`, `hatched`, `rapplication`, `prototype`, `operator`.
 
-Adding a new kind requires a CONSTITUTION amendment because every consumer derives behavior from this token.
+`kind` lives in the `rappid.json` RECORD (read it from there), not as a string prefix. Adding a new kind requires a CONSTITUTION amendment because every consumer derives behavior from this token.
 
 ### §2.2 Door type derivation
 
 - `kind ∈ {twin, operator}` → `door_type = "front_door"`
 - everything else → `door_type = "gate"`
 
-### §2.3 Hex derivation (recommended)
+### §2.3 Hash derivation
 
-`hex = BLAKE2b(f"{owner}/{repo}", digest_size=16).hexdigest()` — deterministic from owner+repo. Or `uuid.uuid4().hex` — random. Either is valid; deterministic is preferred so the same `(owner, repo)` always yields the same rappid and rappids can be regenerated without storage.
+Fresh mints use the full 256-bit identity: `hashlib.sha256(uuid.uuid4().bytes).hexdigest()` (64 hex). When merely restructuring a legacy rappid into the consolidated shape, **preserve the existing hash** — `canonicalize_rappid()` never invents one. The one-time 128→256-bit re-anchor (minting a fresh 64-hex, recording the old id in `_migrated_from`) is a separate, explicit step.
 
 ### §2.4 Reissue, never "patch"
 
-If a rappid's two segments disagree (the historical `@local/local-art-collective` case), the door MUST reissue with a correct rappid. Consumers MUST NOT silently fix up. **Spec says what's true; the network has no fallbacks.**
+A legacy rappid that needs restructuring is canonicalized via `canonicalize_rappid()`, which preserves the hash. Consumers MUST NOT silently fix up identity in place. **Spec says what's true; the network has no fallbacks.**
 
 ---
 
@@ -98,7 +103,7 @@ The operator's **estate** lists every door they own (`created`) plus every door 
 {
   "schema": "rapp-estate/1.1",
   "owner": {
-    "rappid": "rappid:v2:operator:@<gh>/<personal-twin-or-brainstem>:hex@github.com/<gh>/...",
+    "rappid": "rappid:@<gh>/<personal-twin-or-brainstem>:<64hex>",
     "github": "<github-handle>"
   },
   "created": [{"rappid": "...", "added_at": "...", "via": "created" }],
@@ -254,7 +259,7 @@ Every door has a `card.json` at `https://raw.githubusercontent.com/<owner>/<repo
   "abilities": [{"name": "...", "cost": 0, "damage": 0, "text": "...", "type": "..."}],  // 1–4
   "rarity_tier": "starter",                    // starter|core|rare|mythic
   "avatar_svg": "<svg>...</svg>",              // ≤64 KB
-  "meta": {"version": "1.1.2", "kind": "twin", "rappid": "rappid:v2:...", "license": "..."}
+  "meta": {"version": "1.1.2", "kind": "twin", "rappid": "rappid:@<owner>/<slug>:<64hex>", "license": "..."}
 }
 ```
 

--- a/tools/ecosystem_audit.py
+++ b/tools/ecosystem_audit.py
@@ -50,6 +50,7 @@ from ecosystem_contract import (  # noqa: E402
     CONTRACTS, KERNEL_BASE_FILES, SEED_REQUIRED_AGENTS,
     kind_for_entry, contract_for_kind, all_kinds,
 )
+from door_address import parse_rappid, InvalidRappidError  # noqa: E402
 
 
 # ── constants ──────────────────────────────────────────────────────────────
@@ -215,6 +216,7 @@ def _diff_offspring(name: str, kind: str, contract: dict,
     sources_seen = set()
     fingerprint_sha256 = None
     rappid = None
+    record_kind = None  # the `kind` FIELD from the rappid.json record (consolidated form)
 
     # 1. required_files presence
     for path in contract.get("required_files", []):
@@ -245,18 +247,37 @@ def _diff_offspring(name: str, kind: str, contract: dict,
                           "detail": f"expected schema={expected_schema!r}, got {actual_schema!r}"})
         if path == "rappid.json" and isinstance(d, dict):
             rappid = d.get("rappid")
+            record_kind = d.get("kind")  # kind lives in the RECORD, not the string
             try:
                 fingerprint_sha256 = _sha256_bytes(body)
             except Exception:
                 pass
 
-    # 3. rappid_kind_prefix check
-    prefix = contract.get("rappid_kind_prefix")
-    if prefix and rappid is not None:
-        if not isinstance(rappid, str) or not rappid.startswith(prefix):
+    # 3. rappid_kind check.
+    #    The consolidated rappid (rappid:@<owner>/<slug>:<64hex>) carries kind in
+    #    the rappid.json RECORD, never as a "rappid:v2:<kind>:" string prefix. So
+    #    we compare the contract's expected kind against the record's `kind` field,
+    #    falling back to a legacy v2 string's inline kind only when the record omits
+    #    it. The rappid STRING itself is read with the canonical parser, which
+    #    accepts the consolidated form AND every legacy form — we never re-impose a
+    #    "rappid:v2:" prefix requirement, and we never flag a string the prior
+    #    prefix check tolerated (placeholder/local-origin fixtures included).
+    expected_kind = contract.get("rappid_kind")
+    if expected_kind is not None and rappid is not None:
+        parsed = None
+        if isinstance(rappid, str):
+            try:
+                parsed = parse_rappid(rappid)
+            except InvalidRappidError:
+                parsed = None
+        # Prefer the record kind; fall back to a legacy v2 string's inline kind.
+        legacy_inline_kind = parsed.get("kind") if parsed else None
+        actual_kind = record_kind if record_kind is not None else legacy_inline_kind
+        if actual_kind != expected_kind:
             drift.append({"category": "rappid_drift",
                           "path": "rappid.json",
-                          "detail": f"expected rappid prefix {prefix!r}, got {str(rappid)[:64]!r}"})
+                          "detail": f"expected kind={expected_kind!r} (from rappid.json record), "
+                                    f"got {actual_kind!r}"})
 
     # 4. identity_block_required (soul.md must mention "Identity")
     if contract.get("identity_block_required"):

--- a/tools/ecosystem_contract.py
+++ b/tools/ecosystem_contract.py
@@ -42,8 +42,14 @@ SEED_REQUIRED_AGENTS = (
 #   required_files          paths that MUST exist at offspring root
 #                           (or in the named subdir for path-prefixed entries)
 #   expected_schemas        path → canonical schema string the file MUST declare
-#   rappid_kind_prefix      "rappid:v2:<kind>:" prefix the rappid field MUST start with
-#                           (None = no rappid required, e.g. catalog/template)
+#   rappid_kind             the `kind` the offspring's rappid.json RECORD must
+#                           declare. Per the consolidated rappid form
+#                           (rappid:@<owner>/<slug>:<64hex>), kind lives in the
+#                           rappid.json record FIELD, never as a string prefix —
+#                           so the audit reads d["kind"], not a "rappid:v2:<kind>:"
+#                           string prefix. The rappid STRING is validated by shape
+#                           (consolidated or legacy v2, both accepted) separately.
+#                           (None = kind not enforced, e.g. catalog/template/twin)
 #   identity_block_required soul.md must contain the spec-compliant Identity sentinel
 #   rar_required            rar/index.json must exist + sha256-validate against agents/
 #   kernel_base_check       must ship the three KERNEL_BASE_FILES under agents/
@@ -70,7 +76,7 @@ CONTRACTS: dict = {
             "members.json":      "rapp-neighborhood-members/1.0",
             "rar/index.json":    "rapp-rar-index/1.0",
         },
-        "rappid_kind_prefix":      "rappid:v2:neighborhood:",
+        "rappid_kind":             "neighborhood",
         "identity_block_required": True,
         "rar_required":            True,
         "kernel_base_check":       True,
@@ -97,7 +103,7 @@ CONTRACTS: dict = {
             "members.json":      "rapp-neighborhood-members/1.0",
             "rar/index.json":    "rapp-rar-index/1.0",
         },
-        "rappid_kind_prefix":      "rappid:v2:ant-farm:",
+        "rappid_kind":             "ant-farm",
         "identity_block_required": True,
         "rar_required":            True,
         "kernel_base_check":       True,
@@ -117,7 +123,7 @@ CONTRACTS: dict = {
             "rappid.json": "rapp-rappid/2.0",
             "card.json":   "rapp-card/1.0",
         },
-        "rappid_kind_prefix":      None,  # twin rappids may use various kinds (personal/place/experiment/etc.)
+        "rappid_kind":             None,  # twin rappids may use various kinds (personal/place/experiment/etc.)
         "identity_block_required": True,
         "rar_required":            False,  # twins MAY ship rar/ but it's not required
         "kernel_base_check":       False,
@@ -138,7 +144,7 @@ CONTRACTS: dict = {
             "neighborhood.json": "rapp-neighborhood/1.0",
             "members.json":      "rapp-neighborhood-members/1.0",
         },
-        "rappid_kind_prefix":      "rappid:v2:workspace:",
+        "rappid_kind":             "workspace",
         "identity_block_required": False,  # workspaces are private; gate may be terse
         "rar_required":            False,
         "kernel_base_check":       False,
@@ -160,7 +166,7 @@ CONTRACTS: dict = {
             "card.json":         "rapp-card/1.0",
             "rar/index.json":    "rapp-rar-index/1.0",
         },
-        "rappid_kind_prefix":      "rappid:v2:braintrust:",
+        "rappid_kind":             "braintrust",
         "identity_block_required": True,
         "rar_required":            True,
         "kernel_base_check":       True,
@@ -174,7 +180,7 @@ CONTRACTS: dict = {
             "index.html",  # the only required surface
         ],
         "expected_schemas": {},  # catalogs publish their own catalog schema; not enforced here
-        "rappid_kind_prefix":      None,
+        "rappid_kind":             None,
         "identity_block_required": False,
         "rar_required":            False,
         "kernel_base_check":       False,
@@ -190,7 +196,7 @@ CONTRACTS: dict = {
         "expected_schemas": {
             "rappid.json": "rapp-rappid/2.0",
         },
-        "rappid_kind_prefix":      None,  # templates may carry the kind they spawn (workspace/braintrust)
+        "rappid_kind":             None,  # templates may carry the kind they spawn (workspace/braintrust)
         "identity_block_required": False,
         "rar_required":            False,
         "kernel_base_check":       False,
@@ -205,7 +211,7 @@ CONTRACTS: dict = {
             "install.sh",
         ],
         "expected_schemas": {},
-        "rappid_kind_prefix":      None,
+        "rappid_kind":             None,
         "identity_block_required": False,
         "rar_required":            False,
         "kernel_base_check":       False,
@@ -219,7 +225,7 @@ CONTRACTS: dict = {
             "index.json",
         ],
         "expected_schemas": {},  # entries follow rapp-egg-hub-entry/1.0; index shape is a list
-        "rappid_kind_prefix":      None,
+        "rappid_kind":             None,
         "identity_block_required": False,
         "rar_required":            False,
         "kernel_base_check":       False,
@@ -296,7 +302,7 @@ def _self_check() -> dict:
     """Verify the contract is internally consistent. Useful for tests."""
     issues = []
     for kind, c in CONTRACTS.items():
-        for required_field in ("required_files", "expected_schemas", "rappid_kind_prefix",
+        for required_field in ("required_files", "expected_schemas", "rappid_kind",
                                "identity_block_required", "rar_required", "kernel_base_check",
                                "optional_files", "notes"):
             if required_field not in c:

--- a/tools/front_door_specs.py
+++ b/tools/front_door_specs.py
@@ -486,9 +486,10 @@ def _self_check() -> dict:
         for path, content in bundle.items():
             if len(content) < 200:
                 issues.append(f"kind={kind}: {path} too short ({len(content)} bytes)")
-        # SPEC.md must mention rappid v2 and the door URL set
+        # SPEC.md must declare the consolidated rappid form and the door URL set.
+        # (kind lives in the rappid.json record, not a "rappid:v2:<kind>:" prefix.)
         spec = bundle.get("specs/SPEC.md", "")
-        for needle in ("rappid:v2:", "raw.githubusercontent.com", "door_from_rappid"):
+        for needle in ("rappid:@", "raw.githubusercontent.com", "door_from_rappid"):
             if needle not in spec:
                 issues.append(f"SPEC.md missing required mention: {needle!r}")
         # skill.md must mention the GitHub-account-only requirement

--- a/tools/import_peer_egg.py
+++ b/tools/import_peer_egg.py
@@ -36,6 +36,11 @@ import time
 import zipfile
 from pathlib import Path
 
+# The canonical rappid reader (pure stdlib). Reads the consolidated form
+# (rappid:@<owner>/<slug>:<64hex>) AND every legacy form; never reinvent the parse.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from door_address import parse_rappid, owner_repo_from_rappid, InvalidRappidError  # noqa: E402
+
 
 _BRAINSTEM_DIR = Path(os.path.expanduser("~/.brainstem"))
 _PEERS_DIR     = _BRAINSTEM_DIR / "peers"
@@ -82,15 +87,21 @@ def import_egg(egg_path: str, seed_path: Path = _SEED_PATH) -> dict:
             return {"ok": False, "error": f"rappid.json malformed: {e}"}
 
         rappid = rappid_meta.get("rappid", "")
-        if not rappid.startswith("rappid:v2:"):
-            return {"ok": False, "error": f"egg's rappid.json has no v2 rappid: {rappid[:60]}"}
-
-        # Derive the peer's handle from the rappid (Article XLVI parser would
-        # be nicer but stdlib-only here; safe inline parse)
+        # Accept the consolidated form AND every legacy form (parse_rappid reads
+        # them all). The string must be self-locating (carry owner/slug) so we can
+        # derive the peer's handle — a bare UUID can't, and is rejected below.
         try:
-            handle = rappid.split(":@", 1)[1].split("/", 1)[0]
-        except Exception:
-            return {"ok": False, "error": f"could not derive handle from rappid: {rappid[:60]}"}
+            parsed = parse_rappid(rappid) if isinstance(rappid, str) else None
+        except InvalidRappidError:
+            parsed = None
+        if parsed is None:
+            return {"ok": False, "error": f"egg's rappid.json has no recognizable rappid: {str(rappid)[:60]}"}
+
+        # Derive the peer's handle (owner) from the rappid via the canonical parser.
+        try:
+            handle, _repo = owner_repo_from_rappid(rappid)
+        except InvalidRappidError:
+            return {"ok": False, "error": f"could not derive handle from rappid (no location): {str(rappid)[:60]}"}
 
         # Extract to peers/<handle>/
         dest = _PEERS_DIR / handle

--- a/tools/lan_advertise.py
+++ b/tools/lan_advertise.py
@@ -26,7 +26,7 @@ Stdlib + macOS `dns-sd` CLI only. No new pip deps. If `dns-sd` is missing
 peers who already know the URL, but not auto-discoverable via Bonjour).
 
 CANONICAL TXT-RECORD SCHEMA (rapp-network-beacon-bonjour/1.0):
-    rappid       = the operator's personal rappid (operator-kind v2)
+    rappid       = the operator's personal rappid (consolidated form; kind lives in the record)
     github       = the operator's github handle (informational; LAN doesn't need it)
     beacon_path  = "/.well-known/rapp-network.json"
     estate_path  = "/estate.json"
@@ -54,6 +54,11 @@ import sys
 import time
 from pathlib import Path
 
+# Canonical rappid reader (pure stdlib): reads the consolidated form AND every
+# legacy form, so the owner-handle derivation works regardless of rappid vintage.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from door_address import owner_repo_from_rappid, InvalidRappidError  # noqa: E402
+
 _BRAINSTEM_DIR = Path(os.path.expanduser("~/.brainstem"))
 _RAPPID_FILE   = _BRAINSTEM_DIR / "rappid.json"
 _BEACON_PATH   = ".well-known/rapp-network.json"
@@ -69,10 +74,12 @@ def _read_operator_rappid() -> tuple[str, str]:
         d = json.loads(_RAPPID_FILE.read_text())
         rappid = d.get("rappid", "")
         github = d.get("github", "")
-        if not github and rappid.startswith("rappid:v2:"):
+        if not github and isinstance(rappid, str):
+            # Derive the owner handle from any self-locating rappid (consolidated
+            # or legacy). A bare UUID carries no location → leave github empty.
             try:
-                github = rappid.split(":@", 1)[1].split("/", 1)[0]
-            except Exception:
+                github, _repo = owner_repo_from_rappid(rappid)
+            except InvalidRappidError:
                 pass
         return rappid, github
     except Exception:

--- a/tools/rebuild_estate.py
+++ b/tools/rebuild_estate.py
@@ -63,7 +63,21 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "tools"))
 
-from door_address import door_from_rappid, InvalidRappidError, estate_url  # noqa: E402
+from door_address import door_from_rappid, parse_rappid, InvalidRappidError, estate_url  # noqa: E402
+
+
+def _looks_like_rappid(rappid: object) -> bool:
+    """True if `rappid` is a string in ANY known rappid form — the consolidated
+    `rappid:@<owner>/<slug>:<64hex>` OR a legacy form (v2, bare-UUID, …). We read
+    every legacy form forever; canonicalization happens downstream. Used as the
+    cheap "is this worth resolving a door for" gate."""
+    if not isinstance(rappid, str):
+        return False
+    try:
+        parse_rappid(rappid)
+        return True
+    except InvalidRappidError:
+        return False
 
 
 _ESTATE_SCHEMA = "rapp-estate/1.1"
@@ -115,7 +129,7 @@ def _try_local_brainstem() -> str:
     try:
         d = json.loads(p.read_text())
         rappid = d.get("rappid", "")
-        if isinstance(rappid, str) and rappid.startswith("rappid:v2:"):
+        if _looks_like_rappid(rappid):
             return rappid
     except Exception:
         pass
@@ -136,7 +150,7 @@ def _try_conventional_repos(handle: str) -> str:
         if not d:
             continue
         rappid = d.get("rappid", "")
-        if not isinstance(rappid, str) or not rappid.startswith("rappid:v2:"):
+        if not _looks_like_rappid(rappid):
             continue
         # Validate; derive operator rappid by swapping kind token
         try:

--- a/tools/sim/plant_two_brainstems.py
+++ b/tools/sim/plant_two_brainstems.py
@@ -52,8 +52,12 @@ def _write(path: str, content) -> None:
 
 
 def _mint_rappid(kind: str, owner: str, name: str) -> str:
-    h = uuid.uuid4().hex
-    return f"rappid:v2:{kind}:@{owner}/{name}:{h}@local/{owner}/{name}"
+    # Mint the consolidated self-locating Eternity rappid:
+    #   rappid:@<owner>/<slug>:<64hex>  (full 256-bit identity).
+    # `kind` is NOT in the string — it lives in the rappid.json record this
+    # caller writes alongside it; accepted here only for call-site compatibility.
+    h = hashlib.sha256(uuid.uuid4().bytes).hexdigest()  # 64 hex, full 256-bit
+    return f"rappid:@{owner}/{name}:{h}"
 
 
 # ─── Plant a brainstem (twin kind) with a distinct voice ──────────────────


### PR DESCRIPTION
The consolidated rappid — `rappid:@<owner>/<slug>:<64hex>` — is the one **emitted** form: self-locating + full 256-bit identity, with `kind` and all structure living in the `rappid.json` **record**, never in the string. Every legacy form (v2, bare-UUID, bare-Eternity) is still **read forever**.

This sweeps the RAPP repo so future AIs/readers aren't confused by stale "v2 is canonical" assertions.

### EMIT (code that constructs a rappid string)
- `tools/sim/plant_two_brainstems.py`: `_mint_rappid` now mints the consolidated 256-bit form (`hashlib.sha256(uuid.uuid4().bytes).hexdigest()`) instead of `rappid:v2:<kind>:...@host`. `kind` stays in the record it writes.

### DECLARE (format contracts / specs)
- `tools/ecosystem_contract.py`: `rappid_kind_prefix` (`"rappid:v2:<kind>:"`) → `rappid_kind` (the kind **value** read from the `rappid.json` record). `None` stays `None`.
- `tools/ecosystem_audit.py`: check #3 compares the contract's expected kind against the record's `kind` field (legacy v2-inline kind as fallback) instead of requiring a `"rappid:v2:"` string prefix. Still reads every legacy form; does **not** newly reject placeholder/`@local` fixtures the prior prefix check tolerated.
- `tools/front_door_specs.py`: SPEC.md self-check now requires the consolidated `"rappid:@"` mention, not `"rappid:v2:"`.
- `specs/SPEC.md` §2: declares the consolidated form as canonical; v2 kept only as a clearly-labeled legacy form we read forever.

### PARSE (v2-only gates → accept consolidated too, keep reading legacy)
- `tools/rebuild_estate.py`: `startswith("rappid:v2:")` gates → `parse_rappid` via a `_looks_like_rappid()` helper.
- `tools/import_peer_egg.py` & `tools/lan_advertise.py`: v2-prefix gate + inline `split(":@")` handle derivation → `door_address.parse_rappid` / `owner_repo_from_rappid` (works for consolidated AND legacy; a bare UUID correctly has no location).

### Untouched on purpose
- `tools/door_address.py` — the canonical legacy reader (`parse_rappid`/`canonicalize_rappid`), already correct.
- Legacy-read test fixtures (e.g. `tools/holo_card_generator.py` `_self_check` test_rappid; `tests/fixtures/*/rappid.json`).

### Verification
- Offline ecosystem audit: `drift_count=0` (matches baseline).
- `tests/test_door_address.py`: 22/22 pass.
- F10 ecosystem-audit feature test: 10/10 pass (incl. synthetic bare-UUID drift detection).
- F13/F14 failures are pre-existing on `origin/main` (live `gh` discovery / planter), unchanged by this PR.
- All touched `.py` `py_compile` + import-smoke clean. Diff scanned for public-clean tokens: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)