### PR TITLE
Migrate rappid to the Eternity format (Art. XXXIV.1)

### DIFF
--- a/installer/initialize-variant.sh
+++ b/installer/initialize-variant.sh
@@ -37,8 +37,9 @@ fi
 
 # ── Identity (hardcoded — single-parent rule) ────────────────────────────
 
-# Species root v2-format rappid per CONSTITUTION Article XXXIV.1.
-PARENT_RAPPID="rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP"
+# Species root consolidated Eternity rappid per CONSTITUTION Article XXXIV.1.
+# `kind` (prototype) lives in the species-root rappid.json record, not the string.
+PARENT_RAPPID="rappid:@kody-w/RAPP:0b635450c04249fbb4b1bdb571044dec"
 PARENT_REPO="https://github.com/kody-w/RAPP.git"
 
 # ── Freshness check via lineage_check.py ─────────────────────────────────
@@ -95,14 +96,16 @@ VARIANT_NAME="${VARIANT_NAME:-$DEFAULT_NAME}"
 
 # ── Generate rappid ──────────────────────────────────────────────────────
 
-# v2-format rappid per CONSTITUTION Article XXXIV.1. UUID hex (dashes
-# stripped) as hash; pub/slug derived from this repo's git remote.
+# Consolidated Eternity rappid per CONSTITUTION Article XXXIV.1: self-locating
+# `rappid:@<owner>/<slug>:<hash>` (no v2:/<kind>:/@host). UUID hex (dashes
+# stripped) as hash; owner/slug derived from this repo's git remote. The variant
+# `kind`/role lives in the rappid.json record (set below), not the string.
 _VAR_OWNER="$(git config --get remote.origin.url 2>/dev/null | sed -nE 's#.*[/:]([^/]+)/[^/]+(\.git)?$#\1#p')"
 _VAR_OWNER="${_VAR_OWNER:-anon}"
 _VAR_REPO="$(git config --get remote.origin.url 2>/dev/null | sed -nE 's#.*/([^/]+)\.git$#\1#p; s#.*/([^/]+)$#\1#p' | head -1)"
 _VAR_REPO="${_VAR_REPO:-$VARIANT_NAME}"
 _VAR_HASH="$(python3 -c "import uuid; print(uuid.uuid4().hex)")"
-NEW_RAPPID="rappid:v2:variant:@${_VAR_OWNER}/${_VAR_REPO}:${_VAR_HASH}@github.com/${_VAR_OWNER}/${_VAR_REPO}"
+NEW_RAPPID="rappid:@${_VAR_OWNER}/${_VAR_REPO}:${_VAR_HASH}"
 NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 PARENT_COMMIT="$(curl -fsSL "https://api.github.com/repos/kody-w/RAPP/commits/main" 2>/dev/null \
@@ -128,6 +131,8 @@ data["parent_commit"] = parent_commit or None
 data["born_at"] = born_at
 data["name"] = name
 data["role"] = "variant"
+# Eternity standard: `kind` lives in the record (not the rappid string).
+data.setdefault("kind", "variant")
 data["schema"] = "rapp-rappid/2.0"
 # attestation resets because the new rappid hasn't been attested yet.
 data["attestation"] = None

--- a/installer/plant.sh
+++ b/installer/plant.sh
@@ -27,12 +27,13 @@ set -e
 # ── constants ─────────────────────────────────────────────────────────
 GRAIL_REPO="kody-w/rapp-installer"
 GRAIL_RAW="https://raw.githubusercontent.com/${GRAIL_REPO}/main"
-# Species root v2-format rappid — the canonical identifier for kody-w/RAPP
-# per CONSTITUTION Article XXXIV.1 (2026-04-30 ratification). The legacy
-# UUID 0b635450-c042-49fb-b4b1-bdb571044dec is preserved as the hash field
-# (dashes stripped) per the documented migration rule — same identity, new
-# string representation.
-SPECIES_ROOT_RAPPID="rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP"
+# Species root consolidated Eternity rappid — the canonical identifier for
+# kody-w/RAPP per CONSTITUTION Article XXXIV.1 (consolidated form, locked
+# 2026-06-03). The legacy UUID 0b635450-c042-49fb-b4b1-bdb571044dec is preserved
+# as the hash field (dashes stripped) per the documented migration rule — same
+# identity, consolidated string representation. `kind` (prototype) lives in the
+# rappid.json record, not the string.
+SPECIES_ROOT_RAPPID="rappid:@kody-w/RAPP:0b635450c04249fbb4b1bdb571044dec"
 
 KERNEL_FILES=(
     "rapp_brainstem/brainstem.py"
@@ -129,14 +130,16 @@ print(' '.join(p.capitalize() for p in parts))
 
 # ── identity ──────────────────────────────────────────────────────────
 # mint_rappid <gh_user> <repo_name> <kind>
-# Mints a v2-format rappid string per CONSTITUTION Article XXXIV.1.
-# Schema: rappid:v2:<kind>:@<gh_user>/<repo_name>:<hash>@github.com/<gh_user>/<repo_name>
+# Mints a consolidated Eternity rappid string per CONSTITUTION Article XXXIV.1.
+# Schema: rappid:@<gh_user>/<repo_name>:<hash>  (self-locating; no v2:/<kind>:/@host).
+# `kind` is NOT encoded in the string — it lives in the rappid.json record. The
+# parameter is kept for call-site compatibility (and to flow into the record).
 # Hash is a fresh UUIDv4 with dashes stripped (32 hex chars).
 mint_rappid() {
     local gh_user="${1:-anon}" repo_name="${2:-unknown}" kind="${3:-mirror}"
     local hash
     hash="$(python3 -c "import uuid; print(uuid.uuid4().hex)")"
-    echo "rappid:v2:${kind}:@${gh_user}/${repo_name}:${hash}@github.com/${gh_user}/${repo_name}"
+    echo "rappid:@${gh_user}/${repo_name}:${hash}"
 }
 now_iso()     { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 

--- a/installer/test_plant.sh
+++ b/installer/test_plant.sh
@@ -145,7 +145,7 @@ missing = [k for k in required if k not in d]
 if missing:
     print("FAIL  rappid.json missing keys:", missing)
     sys.exit(1)
-SPECIES_ROOT_V2 = "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP"
+SPECIES_ROOT = "rappid:@kody-w/RAPP:0b635450c04249fbb4b1bdb571044dec"
 checks = [
     (d["schema"] == "rapp-rappid/2.0",       "schema is rapp-rappid/2.0"),
     (d["kind"] == "mirror",                  "kind is mirror"),
@@ -153,10 +153,10 @@ checks = [
     (d["display_name"] == "Test Mirror",     "display_name matches input"),
     (d["planted_by"] == "testuser",          "planted_by matches input"),
     (d["kernel_version"] == "0.6.0",         "kernel_version is 0.6.0"),
-    (d["parent_rappid"] == SPECIES_ROOT_V2,  "parent_rappid is species root v2 string"),
-    (d["rappid"].startswith("rappid:v2:"),   "rappid is v2-format string"),
-    (d["rappid"].count(":") >= 4,            "rappid has the v2 separator structure"),
-    (d["rappid"].count("@") == 2,            "rappid has 2 @ separators (kind:@pub/slug:hash@host)"),
+    (d["parent_rappid"] == SPECIES_ROOT,     "parent_rappid is species root Eternity string"),
+    (d["rappid"].startswith("rappid:@"),     "rappid is consolidated Eternity-format string"),
+    (d["rappid"].count(":") == 2,            "rappid has the Eternity separator structure (rappid:@owner/slug:hash)"),
+    (d["rappid"].count("@") == 1,            "rappid has 1 @ separator (@owner/slug)"),
 ]
 for ok_, desc in checks:
     print(("PASS" if ok_ else "FAIL") + "  " + desc)

--- a/rappid.json
+++ b/rappid.json
@@ -1,6 +1,8 @@
 {
   "schema": "rapp-rappid/2.0",
-  "rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "rappid": "rappid:@kody-w/RAPP:0b635450c04249fbb4b1bdb571044dec",
+  "kind": "prototype",
+  "_migrated_from": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
   "parent_rappid": null,
   "parent_repo": null,
   "parent_commit": null,


### PR DESCRIPTION
Applies the Eternity rappid envelope-strip across this repo's identity records (and minting/parsing code). Hashes preserved; prior strings recorded under _migrated_from. Closes #54. No values listed here (no PII).