### PR TITLE
feat(cave): super-RAR capability — full parity with the batcave (public)

### DIFF
--- a/.github/workflows/cave-super-rar.yml
+++ b/.github/workflows/cave-super-rar.yml
@@ -1,0 +1,31 @@
+name: cave super-RAR freshness
+
+# Keep the public RAPP Cave's super-store honest: whenever a cubby's contents or
+# the cave's participation agents change, the committed super-RAR/RAR indexes
+# must have been rebuilt. This is the CI half of the batcave god agent's
+# `super_rar rebuild` — a gate, not a write-back (no loops, no extra perms).
+on:
+  pull_request:
+    paths:
+      - 'cave/cubbies/**'
+      - 'cave/agents/**'
+      - 'cave/rapplications/**'
+      - 'cave/tools/build_super_rar.py'
+  push:
+    branches: [main]
+    paths:
+      - 'cave/cubbies/**'
+      - 'cave/agents/**'
+      - 'cave/rapplications/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Verify the super-RAR indexes are current
+        run: |
+          python3 cave/tools/build_super_rar.py --check

--- a/cave/agents/cave_agent.py
+++ b/cave/agents/cave_agent.py
@@ -1,0 +1,214 @@
+"""
+cave_agent.py — talk to the public RAPP Cave from inside your brainstem.
+
+Drop this into ANY unmodified brainstem's agents/ directory and the LLM gets a
+`Cave` tool that gives your brainstem the SAME super-RAR powers a batcave member
+has — but PUBLIC (plain git clone over HTTPS, no auth, no collaborator gate):
+
+  • list       — the cubbies in the cave (who parked what)
+  • super_rar  — search the super-store: EVERY kind across EVERY cubby
+                 (agents, organs, senses, rapplications, neighborhoods, eggs)
+  • load       — stream a cubby's agents INTO this brainstem's agents/ and
+                 register them in .git/info/exclude → they run but are git-
+                 invisible (ZERO commit risk), verified against the RAR sha256
+                 pins (refuses tampered/drifted files)
+  • sync       — pull the latest cave
+
+It mirrors the batcave god agent's load/super_rar exactly, minus the private
+parts: the cave is public, so it shallow-clones https://github.com/kody-w/RAPP
+to a local cache and reads cave/ from there. Self-contained, stdlib only.
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+
+from agents.basic_agent import BasicAgent
+
+CAVE_REPO = "https://github.com/kody-w/RAPP.git"
+CACHE = os.path.expanduser("~/.brainstem/.cave_cache/RAPP")
+SUPER_RAR_KINDS = {
+    "agent": ("agents", "*_agent.py"), "organ": ("organs", "*_organ.py"),
+    "sense": ("senses", "*.py"), "rapplication": ("rapplications", "*"),
+    "neighborhood": ("neighborhoods", "*"), "egg": ("eggs", "*.egg"),
+}
+# kernel-shipped agents — load NEVER overwrites these (CONSTITUTION Art. XXXIII)
+KERNEL_AGENTS = {"basic_agent.py", "context_memory_agent.py", "manage_memory_agent.py",
+                 "learn_new_agent.py", "swarm_factory_agent.py", "hacker_news_agent.py"}
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,38}[A-Za-z0-9])?$")
+_AGENT_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+_agent\.py$")
+
+
+def _sha256_file(p):
+    with open(p, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def _read_json(p):
+    try:
+        return json.load(open(p))
+    except Exception:
+        return None
+
+
+class CaveAgent(BasicAgent):
+    def __init__(self):
+        self.name = "Cave"
+        self.metadata = {
+            "name": self.name,
+            "description": (
+                "Browse and pull from the PUBLIC RAPP Cave — the open cubby-neighborhood at "
+                "kody-w.github.io/RAPP/cave (the public sibling of the private batcave). Gives this "
+                "brainstem super-RAR powers with no auth: list the cubbies, search the super-store "
+                "(every kind across every cubby), and STREAM a cubby's agents into this brainstem "
+                "git-invisibly (zero commit risk, sha256-verified). Use it to find what someone else "
+                "built and run it here instantly."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "super_rar", "load", "sync"],
+                        "description": (
+                            "list = the cave's cubbies; super_rar = search the super-store across all "
+                            "cubbies (use 'query'/'kind' to filter); load = stream a cubby's agents into "
+                            "THIS brainstem (git-invisible, zero commit risk) — requires 'cubby'; "
+                            "sync = pull the latest cave."
+                        ),
+                    },
+                    "cubby": {"type": "string", "description": "for action=load: which cubby's agents to stream (a github login, e.g. 'kody-w')."},
+                    "query": {"type": "string", "description": "for action=super_rar: substring to match across the super-store (name/purpose/cubby)."},
+                    "kind": {"type": "string", "description": "for action=super_rar: filter to one kind: agent|organ|sense|rapplication|neighborhood|egg."},
+                    "verify": {"type": "boolean", "description": "for action=load: verify each streamed file against the RAR sha256 pin and refuse drift. Default true."},
+                },
+                "required": ["action"],
+            },
+        }
+
+    # ── cave clone management (public, no auth) ──────────────────────────────
+    def _cave_root(self, refresh=False):
+        """Return the local path to cave/ inside a public clone of kody-w/RAPP,
+        cloning/pulling as needed. Prefers an existing neighborhood clone."""
+        for cand in (os.path.expanduser("~/.brainstem/neighborhoods/RAPP"),
+                     os.path.expanduser("~/.brainstem/neighborhoods/RAPP/clone")):
+            if os.path.isdir(os.path.join(cand, "cave")) and os.path.isdir(os.path.join(cand, ".git")):
+                if refresh:
+                    subprocess.run(["git", "-C", cand, "pull", "--ff-only", "-q"], check=False)
+                # only use it if cave/ is actually present on the checked-out branch
+                if os.path.isdir(os.path.join(cand, "cave")):
+                    return os.path.join(cand, "cave")
+        # fall back to a dedicated shallow cache
+        if not os.path.isdir(os.path.join(CACHE, ".git")):
+            os.makedirs(os.path.dirname(CACHE), exist_ok=True)
+            shutil.rmtree(CACHE, ignore_errors=True)
+            subprocess.run(["git", "clone", "--depth", "1", CACHE if False else CAVE_REPO, CACHE], check=False)
+        elif refresh:
+            subprocess.run(["git", "-C", CACHE, "pull", "--ff-only", "-q"], check=False)
+        root = os.path.join(CACHE, "cave")
+        return root if os.path.isdir(root) else None
+
+    def perform(self, **kwargs):
+        action = (kwargs.get("action") or "list").strip()
+        cave = self._cave_root(refresh=(action == "sync"))
+        if not cave:
+            return json.dumps({"ok": False, "error": "could not clone the public cave (need git + network).",
+                               "repo": CAVE_REPO}, indent=2)
+
+        if action == "sync":
+            return json.dumps({"ok": True, "synced": True, "cave": cave}, indent=2)
+
+        if action == "list":
+            idx = _read_json(os.path.join(cave, "cubbies", "index.json")) or {}
+            cubbies = idx.get("cubbies")
+            if not cubbies:
+                cdir = os.path.join(cave, "cubbies")
+                cubbies = [{"github_login": h} for h in sorted(os.listdir(cdir))
+                           if not h.startswith((".", "_")) and os.path.isdir(os.path.join(cdir, h))]
+            return json.dumps({"ok": True, "cave": "kody-w.github.io/RAPP/cave",
+                               "cubbies": cubbies, "next": "super_rar to see what's inside, or load cubby=<login>"}, indent=2)
+
+        if action == "super_rar":
+            sr = _read_json(os.path.join(cave, "super-rar", "index.json")) or {}
+            entries = sr.get("entries", [])
+            q = (kwargs.get("query") or "").strip().lower()
+            kind = (kwargs.get("kind") or "").strip().lower()
+            hits = []
+            for e in entries:
+                if kind and e.get("kind") != kind:
+                    continue
+                hay = f"{e.get('name','')} {e.get('purpose','')} {e.get('cubby','')}".lower()
+                if q and q not in hay:
+                    continue
+                hits.append(e)
+            return json.dumps({"ok": True, "count": len(hits), "by_kind": sr.get("by_kind", {}),
+                               "results": hits[:60],
+                               "note": "streamable agents → `load cubby=<their cubby>`."}, indent=2)
+
+        if action == "load":
+            return self._load(kwargs, cave)
+
+        return json.dumps({"ok": False, "error": f"unknown action {action!r}"}, indent=2)
+
+    # ── stream a cubby's agents into THIS brainstem, git-invisibly ───────────
+    def _load(self, kwargs, cave):
+        handle = (kwargs.get("cubby") or "").strip()
+        if not _HANDLE_RE.match(handle):
+            return json.dumps({"ok": False, "error": "pass cubby=<a cave cubby login>"}, indent=2)
+        src = os.path.join(cave, "cubbies", handle, "agents")
+        if not os.path.isdir(src):
+            return json.dumps({"ok": False, "error": f"no agents/ in cubbies/{handle}/"}, indent=2)
+        bs = kwargs.get("_brainstem_dir") or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        target = os.path.join(bs, "agents")
+        os.makedirs(target, exist_ok=True)
+
+        verify = kwargs.get("verify", True)
+        pins = {}
+        if verify:
+            ridx = _read_json(os.path.join(cave, "rar", "index.json")) or {}
+            for a in ridx.get("agents", []):
+                if a.get("path") and a.get("sha256"):
+                    pins[os.path.basename(a["path"])] = a["sha256"]
+
+        loaded, skipped = [], []
+        for fn in sorted(os.listdir(src)):
+            if not _AGENT_FILE_RE.match(fn):
+                continue
+            if fn in KERNEL_AGENTS:
+                skipped.append({"file": fn, "why": "kernel — never overwritten"}); continue
+            src_file = os.path.join(src, fn)
+            if verify and fn in pins and _sha256_file(src_file) != pins[fn]:
+                skipped.append({"file": fn, "why": "sha256 drift vs RAR pin — refused"}); continue
+            dst = os.path.join(target, fn)
+            if os.path.exists(dst) and _sha256_file(dst) != _sha256_file(src_file):
+                skipped.append({"file": fn, "why": "your own differing file — won't overwrite"}); continue
+            shutil.copy2(src_file, dst)
+            loaded.append(fn)
+
+        excluded = self._register_excludes(bs, loaded)
+        return json.dumps({"ok": True, "from_cubby": handle, "loaded": loaded, "skipped": skipped,
+                           "git_excluded": excluded,
+                           "note": "streamed + git-invisible (.git/info/exclude) — zero commit risk. "
+                                   "Reload the agents (next /chat turn) to use them."}, indent=2)
+
+    @staticmethod
+    def _register_excludes(bs, loaded):
+        """Add streamed files to .git/info/exclude so the host repo never sees them."""
+        info = os.path.join(bs, ".git", "info")
+        if not os.path.isdir(os.path.join(bs, ".git")):
+            return []                              # host brainstem isn't a git repo — nothing to hide
+        os.makedirs(info, exist_ok=True)
+        excl = os.path.join(info, "exclude")
+        have = open(excl).read() if os.path.exists(excl) else ""
+        added = []
+        with open(excl, "a") as f:
+            for fn in loaded:
+                line = f"agents/{fn}"
+                if line not in have:
+                    f.write(line + "\n"); added.append(line)
+        return added

--- a/cave/agents/rar_steward_agent.py
+++ b/cave/agents/rar_steward_agent.py
@@ -1,0 +1,477 @@
+"""RarStewardAgent — the autonomous steward of the public RAR.
+
+A registry rots when it fills with noise: undocumented stubs, placeholders, and
+"same but different" agents that do one thing five slightly-different ways. Left
+alone it becomes unsearchable and low-trust. This agent trolls the RAR catalog
+and reports — operator-mediated, it SUGGESTS, never auto-deletes — on:
+
+  • health     overall quality (card coverage, placeholders, dup pressure) + a score
+  • duplicates clusters of same-but-different agents that should be UNITED into one
+               quality base.py (with a recommended unified name + the members + why)
+  • junk       noise / low-quality candidates to review for removal (no card,
+               stubs, version 0.0.0, placeholder/test names, exact dup ids)
+  • agent name=…  a deep quality assessment of one agent (fetches its full card)
+  • help
+
+It reads the consolidated catalog (api/v1/index.json) in one request; deep
+assessment fetches the per-agent card. Online by nature; degrades cleanly.
+Steward, not executioner: it produces guidance for the operator to act on.
+
+Generic + cover-safe. MIT © Kody Wildfeuer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+
+try:
+    from agents.basic_agent import BasicAgent  # type: ignore
+except ImportError:
+    try:
+        from basic_agent import BasicAgent  # type: ignore
+    except ImportError:
+        class BasicAgent:
+            def __init__(self, name="Agent", metadata=None):
+                self.name = name
+                self.metadata = metadata or {}
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@rapp/rar_steward",
+    "version": "1.0.0",
+    "display_name": "RarStewardAgent",
+    "description": ("Autonomous steward of the public RAR: surveys catalog "
+                    "health, clusters same-but-different agents that should be "
+                    "merged into one quality base, and flags noise/junk for "
+                    "review — operator-mediated guidance, never auto-deletes."),
+    "author": "Kody Wildfeuer",
+    "tags": ["rar", "steward", "registry", "quality", "dedup", "merge", "curation"],
+    "category": "core",
+    "quality_tier": "official",
+    "requires_env": [],
+    "dependencies": ["@rapp/basic_agent"],
+}
+
+RAR = os.environ.get("RAR_REPO", "kody-w/RAR")
+_RAW = "https://raw.githubusercontent.com"
+INDEX_URL = f"{_RAW}/{RAR}/main/api/v1/index.json"
+AGENT_URL = f"{_RAW}/{RAR}/main/api/v1/agent/{{id}}.json"
+
+# Where steward findings become traceable GitHub Issues (public canon only).
+STEWARD_TRACKER = os.environ.get("STEWARD_TRACKER", "kody-w/RAR")
+STEWARD_LABEL = os.environ.get("STEWARD_LABEL", "rar-steward")
+
+# name tokens that carry no distinguishing meaning
+_STOP = {"agent", "the", "a", "an", "of", "for", "to", "and", "or", "rapp",
+         "generator", "helper", "tool", "assistant", "v1", "v2", "py"}
+_PLACEHOLDER = re.compile(r"\b(test|tmp|temp|demo|foo|bar|baz|example|placeholder|untitled|copy|wip|draft|sample|hello[_-]?world)\b", re.IGNORECASE)
+_DUP_THRESHOLD = 0.6   # name-token Jaccard at/above this = merge candidate
+
+
+def _run(cmd, cwd=None):
+    try:
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=120)
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except FileNotFoundError:
+        return 127, "", f"{cmd[0]}: not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", "timed out"
+
+
+def _scrub(text):
+    """Redact tokens/secrets before they enter a return envelope or issue."""
+    if not text:
+        return text
+    text = re.sub(r"gh[pousr]_[A-Za-z0-9]{20,}", "[redacted-token]", text)
+    text = re.sub(r"github_pat_[A-Za-z0-9_]{20,}", "[redacted-token]", text)
+    text = re.sub(r"(?i)(authorization|token|bearer|secret|password)\s*[:=]\s*\S+",
+                  r"\1=[redacted]", text)
+    return text
+
+
+def _now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _fetch(url, timeout=15):
+    import urllib.request
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.read().decode("utf-8", "replace")
+    except Exception:
+        return None
+
+
+def _tokens(text):
+    return {t for t in re.split(r"[^a-z0-9]+", (text or "").lower()) if t and t not in _STOP and len(t) > 1}
+
+
+def _jaccard(a, b):
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+class _UF:
+    def __init__(self, n): self.p = list(range(n))
+    def find(self, x):
+        while self.p[x] != x:
+            self.p[x] = self.p[self.p[x]]; x = self.p[x]
+        return x
+    def union(self, a, b): self.p[self.find(a)] = self.find(b)
+
+
+class RarStewardAgent(BasicAgent):
+    def __init__(self):
+        self.name = "RarStewardAgent"
+        self.metadata = {
+            "name": self.name,
+            "description": ("Steward the public RAR: catalog health, "
+                            "merge-candidate clusters of same-but-different "
+                            "agents, and noise/junk to review. Guidance only — "
+                            "never auto-deletes (operator-mediated)."),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string",
+                               "enum": ["health", "duplicates", "junk", "agent",
+                                        "file_issues", "help"]},
+                    "name": {"type": "string", "description": "agent: rar_name or id to deep-assess"},
+                    "publisher": {"type": "string", "description": "filter to one publisher (e.g. @kody-w)"},
+                    "limit": {"type": "integer", "description": "max clusters/items to return (default 25)"},
+                    "scope": {"type": "string", "enum": ["merge", "junk", "all"],
+                              "description": "file_issues: which findings to file (default all)"},
+                    "confirm": {"type": "boolean",
+                                "description": "file_issues: actually create issues (default false = dry-run plan)"},
+                    "tracker": {"type": "string",
+                                "description": "file_issues: owner/repo to file into (default STEWARD_TRACKER)"},
+                },
+                "required": ["action"],
+            },
+        }
+        super().__init__(self.name, self.metadata)
+
+    def system_context(self):
+        return ("RarStewardAgent can audit the public RAR for quality — "
+                "duplicate/same-but-different agents to merge, and noise to "
+                "prune. Use it when asked to keep the registry clean/usable. "
+                "It only suggests; the operator acts.")
+
+    def _env(self, action, status, **f):
+        return json.dumps({"schema": "rapp-rar-steward/1.0", "action": action,
+                           "status": status, **f}, indent=2, ensure_ascii=False)
+
+    def _catalog(self, publisher=None):
+        text = _fetch(INDEX_URL)
+        if not text:
+            return None
+        try:
+            d = json.loads(text)
+        except ValueError:
+            return None
+        agents = d.get("agents", [])
+        if publisher:
+            agents = [a for a in agents if a.get("publisher") == publisher or a.get("publisher") == "@" + publisher.lstrip("@")]
+        return agents
+
+    def _clusters(self, agents):
+        """Union-find clusters of same-but-different agents by name-token
+        similarity (boosted when same category)."""
+        toks = [_tokens(a.get("name", "") + " " + a.get("id", "").split("__")[-1]) for a in agents]
+        uf = _UF(len(agents))
+        pairs = []
+        for i in range(len(agents)):
+            for j in range(i + 1, len(agents)):
+                if not toks[i] or not toks[j]:
+                    continue
+                sim = _jaccard(toks[i], toks[j])
+                same_cat = agents[i].get("category") and agents[i].get("category") == agents[j].get("category")
+                thresh = _DUP_THRESHOLD - (0.1 if same_cat else 0)
+                if sim >= thresh:
+                    uf.union(i, j); pairs.append((i, j, round(sim, 2)))
+        groups = {}
+        for idx in range(len(agents)):
+            groups.setdefault(uf.find(idx), []).append(idx)
+        clusters = []
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            ag = [agents[i] for i in members]
+            common = set.intersection(*[toks[i] for i in members]) if all(toks[i] for i in members) else set()
+            base = "_".join(sorted(common)) or "_".join(sorted(_tokens(ag[0].get("name", "")))[:2]) or "unified"
+            clusters.append({
+                "recommended_base": f"{base}_agent.py",
+                "size": len(ag),
+                "publishers": sorted({a.get("publisher") for a in ag}),
+                "category": ag[0].get("category"),
+                "members": [{"rar_name": a.get("rar_name"), "name": a.get("name"),
+                             "publisher": a.get("publisher")} for a in ag],
+                "why": ("these share the core name tokens " +
+                        (", ".join(sorted(common)) if common else "(near-overlap)") +
+                        " — same job, slightly different; unite into one quality base "
+                        "covering the union of their inputs/outputs."),
+            })
+        clusters.sort(key=lambda c: -c["size"])
+        return clusters
+
+    def _junk(self, agents):
+        out = []
+        seen = {}
+        for a in agents:
+            reasons = []
+            name = a.get("name", "")
+            rid = a.get("id", "")
+            if not a.get("has_card"):
+                reasons.append("no card (undocumented — no summary/tags)")
+            ver = str(a.get("version", ""))
+            if ver in ("", "0.0.0") or ver.endswith("-stub") or ver.startswith("0.0"):
+                reasons.append(f"pre-release/stub version ({ver or 'none'})")
+            if _PLACEHOLDER.search(name) or _PLACEHOLDER.search(rid):
+                reasons.append("placeholder/test name")
+            key = (a.get("rar_name") or rid).lower()
+            if key in seen:
+                reasons.append(f"exact duplicate rar_name of {seen[key]}")
+            else:
+                seen[key] = a.get("rar_name") or rid
+            if reasons:
+                out.append({"rar_name": a.get("rar_name"), "name": name,
+                            "publisher": a.get("publisher"), "reasons": reasons})
+        return out
+
+    # ── shared issue-filing contract (rapp-drift-issue/1.0) ──────────────────
+    #   items: list of {title, fingerprint, body_md, machine}
+    #   tracker: "owner/repo"  label: e.g. "rar-steward"  prefix: e.g. "drift"
+    #   confirm: bool (default FALSE upstream — filing public issues is opt-in)
+    # Idempotent: a stable fingerprint per finding means same drift => same fp =>
+    # no duplicate issue. Cover-safe: only public canon ever lands in title/body.
+    def _file_issues(self, items, tracker, label, prefix, confirm):
+        """Idempotent Issue filer (same contract as the drift agent). Dedupe by
+        ONE exhaustive label-scoped listing (search of a hex in a code fence is
+        unreliable); the fp also rides the TITLE. Fail-safe: if we can't list,
+        refuse to file. COVER: callers put only public canon in title/body."""
+        filed, skipped_existing, planned = [], [], []
+        rc, out, err = _run(["gh", "issue", "list", "--repo", tracker,
+                             "--label", label, "--state", "all", "--limit", "500",
+                             "--json", "number,title,body"])
+        if rc != 0:
+            return {"tracker": tracker, "label": label, "confirm": confirm,
+                    "error": ("could not list existing issues to dedupe (" +
+                              _scrub((err or "").strip())[:160] +
+                              ") — refusing to file to avoid duplicates."),
+                    "filed": [], "skipped_existing": [], "planned": []}
+        existing = {}
+        try:
+            for it in json.loads(out or "[]"):
+                blob = (it.get("title", "") or "") + "\n" + (it.get("body", "") or "")
+                for fpm in re.findall(r"(?:fp:|\"fingerprint\"\s*:\s*\")([0-9a-f]{12})", blob):
+                    existing.setdefault(fpm, it.get("number"))
+        except ValueError:
+            pass
+        labelled = False
+        for item in items:
+            fp = item["fingerprint"]
+            title = f"[{prefix}] {item['title']} (fp:{fp})"
+            machine = {"schema": "rapp-drift-issue/1.0", "fingerprint": fp,
+                       "prefix": prefix, **(item.get("machine") or {})}
+            body = (item["body_md"] + "\n\n```json\n" +
+                    json.dumps(machine, ensure_ascii=False) + "\n```\n")
+            if fp in existing:
+                skipped_existing.append({"fingerprint": fp, "title": title,
+                                         "number": existing[fp]})
+                continue
+            if not confirm:
+                planned.append({"title": title, "fingerprint": fp, "would_file": True})
+                continue
+            if not labelled:
+                _run(["gh", "label", "create", label, "--repo", tracker, "--force"])
+                labelled = True
+            crc, cout, cerr = _run(["gh", "issue", "create", "--repo", tracker,
+                                    "--title", title, "--body", body, "--label", label])
+            if crc == 0 and cout:
+                filed.append(cout.strip().splitlines()[-1])
+            else:
+                planned.append({"title": title, "fingerprint": fp,
+                                "would_file": True, "error": _scrub(cerr) or "create failed"})
+            existing[fp] = "just-filed"
+        return {"tracker": tracker, "label": label, "confirm": confirm,
+                "filed": filed, "skipped_existing": skipped_existing, "planned": planned}
+
+    def _fp(self, *parts):
+        key = "|".join(str(p) for p in parts)
+        return hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+
+    def perform(self, **kwargs):
+        action = (kwargs.get("action") or "health").lower()
+        if action == "help" or action not in ("health", "duplicates", "junk",
+                                               "agent", "file_issues"):
+            return (
+                "RarStewardAgent — keep the public RAR clean + usable.\n"
+                "  action=health           catalog health + quality score\n"
+                "  action=duplicates       same-but-different clusters to UNITE into one base\n"
+                "  action=junk             noise/low-quality candidates to review (no auto-delete)\n"
+                "  action=agent name=…     deep quality assessment of one agent\n"
+                "  action=file_issues      turn merge-cluster + junk findings into GitHub Issues\n"
+                "                          scope=merge|junk|all (default all); confirm=true to file\n"
+                "                          (default dry-run — plans only; tracker=owner/repo override)\n"
+                "  publisher=@kody-w       (optional) scope any action to one publisher\n"
+                "Steward, not executioner: it suggests; the operator acts.")
+
+        limit = kwargs.get("limit") or 25
+
+        if action == "agent":
+            nm = (kwargs.get("name") or "").strip()
+            if not nm:
+                return self._env(action, "error", error="pass name=<rar_name or id>")
+            agents = self._catalog() or []
+            hit = next((a for a in agents if nm in (a.get("rar_name", "") + " " + a.get("id", ""))), None)
+            if not hit:
+                return self._env(action, "not_found", name=nm)
+            card = None
+            cj = _fetch(AGENT_URL.format(id=hit["id"]))
+            if cj:
+                try: card = json.loads(cj)
+                except ValueError: pass
+            score, notes = 100, []
+            if not hit.get("has_card"): score -= 40; notes.append("no card")
+            summ = (card or {}).get("summary") or (card or {}).get("description") or ""
+            if len(summ) < 40: score -= 20; notes.append("thin/absent summary")
+            if not ((card or {}).get("tags")): score -= 15; notes.append("no tags")
+            if _PLACEHOLDER.search(hit.get("name", "")): score -= 25; notes.append("placeholder name")
+            return self._env(action, "success", rar_name=hit.get("rar_name"),
+                             quality_score=max(0, score), notes=notes or ["looks healthy"],
+                             summary=summ[:200], category=hit.get("category"))
+
+        agents = self._catalog(kwargs.get("publisher"))
+        if agents is None:
+            return self._env(action, "offline",
+                             note="could not reach the RAR catalog (api/v1/index.json). Try again online.")
+        if not agents:
+            return self._env(action, "empty", note="no agents matched.")
+
+        if action == "file_issues":
+            scope = (kwargs.get("scope") or "all").lower()
+            if scope not in ("merge", "junk", "all"):
+                scope = "all"
+            confirm = bool(kwargs.get("confirm", False))   # dry-run default
+            tracker = (kwargs.get("tracker") or STEWARD_TRACKER).strip()
+            items = []
+
+            if scope in ("merge", "all"):
+                for c in self._clusters(agents):
+                    members = [m["rar_name"] for m in c["members"]]
+                    fp = self._fp("merge", *sorted(members))
+                    body = (
+                        f"**Merge candidate** — {c['size']} same-but-different agents.\n\n"
+                        f"Recommended unified base: `{c['recommended_base']}`\n\n"
+                        "Members:\n" +
+                        "".join(f"- `{m}`\n" for m in sorted(members)) +
+                        f"\nWhy: {c['why']}\n\n"
+                        "Unite into one quality base (operator-mediated). Steward "
+                        "suggests; the operator authors the base and retires the variants.")
+                    items.append({
+                        "title": f"merge {c['size']} same-but-different → {c['recommended_base']}",
+                        "fingerprint": fp,
+                        "body_md": body,
+                        "machine": {"kind": "merge",
+                                    "recommended_base": c["recommended_base"],
+                                    "members": members},
+                    })
+
+            if scope in ("junk", "all"):
+                _CONFIRMABLE = ("no card", "placeholder", "duplicate")
+                for j in self._junk(agents):
+                    reasons = j["reasons"]
+                    joined = " ".join(reasons).lower()
+                    if not any(k in joined for k in _CONFIRMABLE):
+                        continue
+                    fp = self._fp("junk", j["rar_name"], *reasons)
+                    body = (
+                        f"**Review candidate** — `{j['rar_name']}`\n\n"
+                        "Reasons flagged:\n" +
+                        "".join(f"- {r}\n" for r in reasons) +
+                        "\nReview and either add a card or retire the noise "
+                        "(operator-mediated). The steward never deletes.")
+                    items.append({
+                        "title": f"review: {j['rar_name']} ({', '.join(reasons)})",
+                        "fingerprint": fp,
+                        "body_md": body,
+                        "machine": {"kind": "junk", "rar_name": j["rar_name"],
+                                    "reasons": reasons},
+                    })
+
+            result = self._file_issues(items, tracker, STEWARD_LABEL,
+                                       "rar-steward", confirm)
+            return self._env(action, "success", scope=scope, scanned=len(agents),
+                             candidates=len(items), result=result,
+                             ruling=("Operator-mediated traceability: each finding becomes "
+                                     "one idempotent GitHub Issue (same finding => same "
+                                     "fingerprint => no dup). Dry-run by default — set "
+                                     "confirm=true to actually file. Only public canon "
+                                     "lands in issue titles/bodies."))
+
+        if action == "duplicates":
+            clusters = self._clusters(agents)
+            dup_agents = sum(c["size"] for c in clusters)
+            return self._env(action, "success",
+                             scanned=len(agents), clusters=len(clusters),
+                             agents_in_clusters=dup_agents,
+                             merge_candidates=clusters[:limit],
+                             ruling=("Operator-mediated: for each cluster, author ONE quality "
+                                     "base agent covering the union of behaviors, publish it, "
+                                     "and retire the redundant variants (keep lineage). Never "
+                                     "auto-merge — these are suggestions for review."))
+
+        if action == "junk":
+            junk = self._junk(agents)
+            by_reason = {}
+            for j in junk:
+                for r in j["reasons"]:
+                    by_reason[r.split(" (")[0]] = by_reason.get(r.split(" (")[0], 0) + 1
+            return self._env(action, "success", scanned=len(agents),
+                             flagged=len(junk), by_reason=by_reason,
+                             candidates=junk[:limit],
+                             ruling=("Review candidates; remove true noise (placeholders, "
+                                     "stubs, exact dups) and add cards to the undocumented. "
+                                     "Operator decides — the steward never deletes."))
+
+        # health (default)
+        clusters = self._clusters(agents)
+        junk = self._junk(agents)
+        n = len(agents)
+        carded = sum(1 for a in agents if a.get("has_card"))
+        placeholders = sum(1 for a in agents if _PLACEHOLDER.search(a.get("name", "")))
+        in_clusters = sum(c["size"] for c in clusters)
+        publishers = {}
+        for a in agents:
+            publishers[a.get("publisher", "?")] = publishers.get(a.get("publisher", "?"), 0) + 1
+        # 0-100 health: card coverage, low placeholder rate, low dup pressure
+        card_cov = carded / n
+        dup_pressure = in_clusters / n
+        ph_rate = placeholders / n
+        score = round(100 * (0.45 * card_cov + 0.35 * (1 - dup_pressure) + 0.20 * (1 - ph_rate)))
+        grade = ("A" if score >= 85 else "B" if score >= 70 else "C" if score >= 55 else "D")
+        return self._env(action, "success", surveyed_at=_now(),
+                         total_agents=n,
+                         by_publisher=dict(sorted(publishers.items(), key=lambda kv: -kv[1])),
+                         card_coverage=f"{round(card_cov*100)}%",
+                         merge_clusters=len(clusters),
+                         agents_in_merge_clusters=in_clusters,
+                         junk_candidates=len(junk),
+                         placeholder_agents=placeholders,
+                         health_score=score, grade=grade,
+                         top_merge_clusters=[{"base": c["recommended_base"], "size": c["size"],
+                                              "members": [m["rar_name"] for m in c["members"]]}
+                                             for c in clusters[:8]],
+                         guidance=("Raise the score by: (1) uniting the merge clusters into "
+                                   "single quality bases, (2) adding cards to the undocumented, "
+                                   "(3) pruning placeholders/stubs. action=duplicates and "
+                                   "action=junk give the worklists. Steward suggests; you act."))
+
+
+if __name__ == "__main__":
+    print(RarStewardAgent().perform(action="help"))

--- a/cave/rar/index.json
+++ b/cave/rar/index.json
@@ -3,30 +3,45 @@
   "neighborhood_rappid": "rappid:@kody-w/rapp-cave:ca72ca0a3cb90c357fb09e38b02f85f09935cacbf61e94740c57f1eb30a73e0a",
   "rar_for": "kody-w/RAPP",
   "kind": "workspace",
-  "updated_at": "2026-06-27T02:40:04Z",
   "raw_url_prefix": "https://raw.githubusercontent.com/kody-w/RAPP/main/cave",
   "note": "Per-neighborhood registry. PUBLIC repo: raw URLs need NO auth \u2014 anyone can stream every pinned file directly with plain curl or off GitHub Pages (https://raw.githubusercontent.com/kody-w/RAPP/main/cave/... or https://kody-w.github.io/RAPP/cave/). No clone, no gh-auth, no collaborator gate \u2014 the public front door is open. Join = fork + PR (or just pull). sha256 pins let loaders verify streamed files against this manifest.",
+  "updated_at": "2026-06-27T13:32:56Z",
   "agents": [
     {
+      "name": "@kody-w/cave",
+      "version": "1.0.0",
+      "path": "agents/cave_agent.py",
+      "sha256": "c8480ab51c661939d74b91e78f0c33c121034da114d5956494e3cf192db3c45b",
+      "purpose": "Cave participation agent: cave.",
+      "required_by_tether": false,
+      "schema": "rapp-agent/1.0"
+    },
+    {
+      "name": "@rapp/rar_steward",
+      "version": "1.0.0",
+      "path": "agents/rar_steward_agent.py",
+      "sha256": "fa38826bf176d010c6c329b330ec93e0e6ed7b6459cabfd1455bbe4ae39bc14c",
+      "purpose": "RarStewardAgent \u2014 the autonomous steward of the public RAR.",
+      "required_by_tether": false,
+      "schema": "rapp-agent/1.0"
+    },
+    {
       "name": "@kody-w/rapp_installer",
-      "version": "0.6.1-cubby",
+      "version": "0.0.0-cubby",
       "path": "cubbies/kody-w/agents/rapp_installer_agent.py",
       "sha256": "acdccb947f9001bcff4f3e1b8bf84bb6b831522a2c7df0d6cffa3cbdae5bfc80",
-      "purpose": "Drive the self-contained, repo-independent RAPP Installer rapplication (status / bootstrap one-liner / health) from any brainstem \u2014 the grail ported out of its repo. Stream via `cave load cubby=kody-w` or plain public curl.",
+      "purpose": "Cubby agent from @kody-w \u2014 stream via `cave load cubby=kody-w`.",
       "required_by_tether": false,
       "schema": "rapp-agent/1.0"
     }
   ],
-  "organs": [],
-  "senses": [],
   "rapps": [
     {
       "name": "@kody-w/rapp-installer",
-      "version": "0.6.1",
-      "path": "rapplications/rapp-installer/",
-      "purpose": "The rapp-installer grail brainstem, carved out of its git repo into a self-contained, egged rapplication \u2014 full installer parity (T1/T2/T3), self-bootstrapping (hatch.py/bootstrap.sh), zero grail-commit risk. PUBLIC pull (no auth): curl -fsSL https://raw.githubusercontent.com/kody-w/RAPP/main/cave/rapplications/rapp-installer/bootstrap.sh | bash",
+      "version": "0.0.0",
       "schema": "rapp-rapplication/1.0",
-      "agent_sha256": "eae07bfd67b5e5f1b21fc62c7d3d33e1c2bd414ff74be04746f21c700ff789a9"
+      "path": "rapplications/rapp-installer/",
+      "purpose": "Cave flagship rapplication: rapp-installer. Pull: curl -fsSL https://raw.githubusercontent.com/kody-w/RAPP/main/cave/rapplications/rapp-installer/bootstrap.sh | bash"
     }
   ],
   "verification": {

--- a/cave/specs/README.md
+++ b/cave/specs/README.md
@@ -22,6 +22,10 @@ fork + PR.
   `curl` / `git clone`, no auth), personal branches, the signed `rapp-cave-event/1.0`
   show-and-tell stream, the public front door, and **fork + PR** joining. Section
   §9 is the side-by-side of how the public cave differs from the private batcave.
+- **[`SUPER_RAR.md`](./SUPER_RAR.md)** — the **super-RAR** capability (full parity
+  with the batcave, public): the RAR + super-store indexes, the `build_super_rar.py`
+  builder, the drop-in `Cave` agent (`list` / `super_rar` / `load`, git-invisible
+  streaming), the `rar_steward`, and the CI freshness gate.
 
 ## How this relates to the wider RAPP specs
 

--- a/cave/specs/SUPER_RAR.md
+++ b/cave/specs/SUPER_RAR.md
@@ -1,0 +1,48 @@
+# The Cave super-RAR — the public super-store
+
+The RAPP Cave has the **same super-RAR capability as the private batcave**, just
+public (plain git/HTTPS, no auth, no collaborator gate).
+
+- **RAR** (`rar/index.json`) — the agent + rapplication registry, every entry
+  sha256-pinned. `cave load` verifies a streamed file against its pin and
+  **refuses drift** (a tampered cubby file never lands in your brainstem).
+- **super-RAR** (`super-rar/index.json`) — the *super-store*: **every kind across
+  every cubby** (agents · organs · senses · rapplications · neighborhoods · eggs),
+  one registry over the whole open neighborhood. Find what a neighbor already
+  built and stream it in.
+
+## The capability (three parts)
+
+| Part | File | What it does |
+|---|---|---|
+| **Builder** | `tools/build_super_rar.py` | (Re)builds both indexes from the cubbies on disk. The standalone, pure-stdlib equivalent of the batcave god agent's `super_rar rebuild`. `--check` mode is the CI gate. |
+| **Agent** | `agents/cave_agent.py` (`@kody-w/cave`) | Drop into any brainstem → a `Cave` tool: `list` cubbies · `super_rar` (search the super-store) · `load cubby=<login>` (stream that cubby's agents into your brainstem, **git-invisible** via `.git/info/exclude`, sha-verified — zero commit risk) · `sync`. |
+| **Steward** | `agents/rar_steward_agent.py` (`@rapp/rar_steward`) | Registry hygiene — dedup/assess agents in the RAR. |
+
+## Get the capability into your brainstem (public, no auth)
+
+```bash
+# drop the Cave agent (and the steward) into your brainstem, then just ask it
+curl -fsSL https://kody-w.github.io/RAPP/cave/agents/cave_agent.py    -o ~/.brainstem/src/rapp_brainstem/agents/cave_agent.py
+curl -fsSL https://kody-w.github.io/RAPP/cave/agents/rar_steward_agent.py -o ~/.brainstem/src/rapp_brainstem/agents/rar_steward_agent.py
+```
+Then in chat: *"list the cave cubbies"*, *"search the cave super-rar for X"*,
+*"load kody-w's agents from the cave"*.
+
+## Freshness
+
+The super-RAR is **living**, not hand-maintained: `tools/build_super_rar.py`
+regenerates it from the cubbies, and `.github/workflows/cave-super-rar.yml`
+**gates every PR** — if you change a cubby and don't rebuild, CI fails. Rebuild
+locally with:
+
+```bash
+python3 cave/tools/build_super_rar.py
+```
+
+## Difference from the batcave
+
+Identical mechanism (build + sha-pin + stream + `.git/info/exclude` zero-commit-risk).
+The only delta is **trust/access**: the batcave streams from a private,
+collaborator-gated clone; the cave streams from the **public** `kody-w/RAPP`
+clone — anyone, no auth.

--- a/cave/super-rar/index.json
+++ b/cave/super-rar/index.json
@@ -1,8 +1,9 @@
 {
   "schema": "rapp-super-rar/1.0",
   "neighborhood_rappid": "rappid:@kody-w/rapp-cave:ca72ca0a3cb90c357fb09e38b02f85f09935cacbf61e94740c57f1eb30a73e0a",
-  "built_at": "2026-06-27T02:40:04Z",
   "note": "The super-RAR \u2014 the cave's super-store. A standard RAR stocks agents; this carries the WHOLE RAPP stack (agents, organs, senses, rapplications, neighborhoods, eggs) across every cubby \u2014 one PUBLIC registry over the full ecosystem. Anyone can browse and stream every entry with plain curl off the public raw base (no auth, no collaborator gate, no clone). Find what a neighbor already built and stream it in. Rebuild with `cave super_rar rebuild=true`.",
+  "raw_url_prefix": "https://raw.githubusercontent.com/kody-w/RAPP/main/cave",
+  "built_at": "2026-06-27T13:32:56Z",
   "count": 2,
   "by_kind": {
     "agent": 1,
@@ -10,20 +11,20 @@
   },
   "entries": [
     {
-      "kind": "egg",
-      "name": "cubby-rapp-installer.egg",
-      "cubby": "kody-w",
-      "path": "cubbies/kody-w/eggs/cubby-rapp-installer.egg",
-      "streamable": false,
-      "sha256": "eae07bfd67b5e5f1b21fc62c7d3d33e1c2bd414ff74be04746f21c700ff789a9"
-    },
-    {
       "kind": "agent",
       "name": "rapp_installer_agent.py",
       "cubby": "kody-w",
       "path": "cubbies/kody-w/agents/rapp_installer_agent.py",
       "streamable": true,
       "sha256": "acdccb947f9001bcff4f3e1b8bf84bb6b831522a2c7df0d6cffa3cbdae5bfc80"
+    },
+    {
+      "kind": "egg",
+      "name": "cubby-rapp-installer.egg",
+      "cubby": "kody-w",
+      "path": "cubbies/kody-w/eggs/cubby-rapp-installer.egg",
+      "streamable": false,
+      "sha256": "eae07bfd67b5e5f1b21fc62c7d3d33e1c2bd414ff74be04746f21c700ff789a9"
     }
   ]
 }

--- a/cave/tools/build_super_rar.py
+++ b/cave/tools/build_super_rar.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+build_super_rar.py — (re)build the RAPP Cave's super-RAR + RAR indexes from the
+cubbies on disk. The public-cave equivalent of the batcave god agent's
+`super_rar rebuild` — extracted into a standalone, pure-stdlib tool so the cave
+is a LIVING super-store, not a hand-maintained file.
+
+The super-RAR is the super-store: EVERY kind across EVERY cubby (agents, organs,
+senses, rapplications, neighborhoods, eggs) — one registry over the whole open
+neighborhood. The RAR is the agent/rapplication registry with sha256 pins that
+`cave load` verifies against before streaming a file into your brainstem.
+
+USAGE
+    python3 cave/tools/build_super_rar.py            # rebuild in place
+    python3 cave/tools/build_super_rar.py --check    # verify the committed indexes are current (CI)
+
+Run from anywhere; it locates the cave root relative to this file. Pure stdlib.
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+# kind -> (anatomy subdir, glob) — identical to the batcave god agent's SUPER_RAR_KINDS
+SUPER_RAR_KINDS = {
+    "agent": ("agents", "*_agent.py"),
+    "organ": ("organs", "*_organ.py"),
+    "sense": ("senses", "*.py"),
+    "rapplication": ("rapplications", "*"),
+    "neighborhood": ("neighborhoods", "*"),
+    "egg": ("eggs", "*.egg"),
+}
+CAVE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))   # cave/tools/.. -> cave/
+CUBBIES = os.path.join(CAVE, "cubbies")
+RAW_PREFIX = "https://raw.githubusercontent.com/kody-w/RAPP/main/cave"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sha256_file(p: str) -> str:
+    with open(p, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def _purpose(py_path: str) -> str:
+    """First docstring line of a .py agent, for the registry blurb."""
+    try:
+        head = open(py_path, encoding="utf-8", errors="ignore").read(1200)
+        m = re.search(r'"""(.+?)(?:\n|""")', head)
+        return m.group(1).strip()[:140] if m else ""
+    except OSError:
+        return ""
+
+
+def build_super_rar() -> list[dict]:
+    """Every kind across every cubby — the super-store."""
+    entries = []
+    if not os.path.isdir(CUBBIES):
+        return entries
+    for handle in sorted(os.listdir(CUBBIES)):
+        if handle.startswith((".", "_")):           # skip _template + hidden
+            continue
+        for kind, (sub, pat) in SUPER_RAR_KINDS.items():
+            for p in sorted(glob.glob(os.path.join(CUBBIES, handle, sub, pat))):
+                name = os.path.basename(p)
+                if name.startswith(".") or name == "__pycache__":
+                    continue
+                e = {"kind": kind, "name": name, "cubby": handle,
+                     "path": os.path.relpath(p, CAVE).replace(os.sep, "/"),
+                     "streamable": kind == "agent"}
+                if os.path.isfile(p):
+                    e["sha256"] = _sha256_file(p)
+                    if p.endswith(".py"):
+                        pr = _purpose(p)
+                        if pr:
+                            e["purpose"] = pr
+                entries.append(e)
+    return entries
+
+
+def _load_header(path: str, defaults: dict) -> dict:
+    """Preserve a registry's header fields (schema, rappid, prefixes, note)."""
+    cur = {}
+    if os.path.exists(path):
+        try:
+            cur = json.load(open(path))
+        except Exception:
+            cur = {}
+    return {k: cur.get(k, v) for k, v in defaults.items()}
+
+
+def render_super_rar() -> dict:
+    entries = build_super_rar()
+    by_kind: dict[str, int] = {}
+    for e in entries:
+        by_kind[e["kind"]] = by_kind.get(e["kind"], 0) + 1
+    hdr = _load_header(os.path.join(CAVE, "super-rar", "index.json"), {
+        "schema": "rapp-super-rar/1.0",
+        "neighborhood_rappid": "rappid:@kody-w/rapp-cave:ca72ca0a3cb90c357fb09e38b02f85f09935cacbf61e94740c57f1eb30a73e0a",
+        "note": ("The super-RAR — the public cave's super-store. A standard RAR stocks "
+                 "agents; this carries the WHOLE stack (agents, organs, senses, rapplications, "
+                 "neighborhoods, eggs) across every cubby. PUBLIC: raw URLs need NO auth. "
+                 "Rebuild with `python3 cave/tools/build_super_rar.py`."),
+        "raw_url_prefix": RAW_PREFIX,
+    })
+    return {**hdr, "built_at": _now(), "count": len(entries), "by_kind": by_kind, "entries": entries}
+
+
+def _manifest_name(py_path: str, default: str) -> tuple[str, bool]:
+    """Pull @ns/name + required_by_tether out of a __manifest__ literal, cheaply."""
+    try:
+        head = open(py_path, encoding="utf-8", errors="ignore").read(2500)
+        m = re.search(r'"name"\s*:\s*"(@[^"]+)"', head)
+        name = m.group(1) if m else default
+        req = bool(re.search(r'"required_by_tether"\s*:\s*[Tt]rue', head))
+        return name, req
+    except OSError:
+        return default, False
+
+
+def render_rar() -> dict:
+    """The RAR: the cave's own participation agents + cubby agents (sha-pinned,
+    streamable) + rapplications."""
+    agents, rapps = [], []
+    # neighborhood-level participation kit (cave/agents/) — the cave's own agents,
+    # like the batcave's @rapp/rapp. These are what a member curls to drive the cave.
+    for p in sorted(glob.glob(os.path.join(CAVE, "agents", "*_agent.py"))):
+        base = os.path.basename(p)[:-len("_agent.py")]
+        name, req = _manifest_name(p, f"@kody-w/{base}")
+        agents.append({
+            "name": name, "version": "1.0.0", "path": f"agents/{os.path.basename(p)}",
+            "sha256": _sha256_file(p), "purpose": _purpose(p) or f"Cave participation agent: {base}.",
+            "required_by_tether": req, "schema": "rapp-agent/1.0",
+        })
+    if os.path.isdir(CUBBIES):
+        for handle in sorted(os.listdir(CUBBIES)):
+            if handle.startswith((".", "_")):
+                continue
+            for p in sorted(glob.glob(os.path.join(CUBBIES, handle, "agents", "*_agent.py"))):
+                rel = os.path.relpath(p, CAVE).replace(os.sep, "/")
+                agents.append({
+                    "name": f"@{handle}/{os.path.basename(p)[:-len('_agent.py')]}",
+                    "version": "0.0.0-cubby", "path": rel, "sha256": _sha256_file(p),
+                    "purpose": _purpose(p) or f"Cubby agent from @{handle} — stream via `cave load cubby={handle}`.",
+                    "required_by_tether": False, "schema": "rapp-agent/1.0",
+                })
+            for d in sorted(glob.glob(os.path.join(CUBBIES, handle, "rapplications", "*"))):
+                if os.path.isdir(d):
+                    rapps.append({
+                        "name": f"@{handle}/{os.path.basename(d)}", "version": "0.0.0-cubby",
+                        "path": os.path.relpath(d, CAVE).replace(os.sep, "/") + "/",
+                        "purpose": f"Rapplication bundle from @{handle}.", "schema": "rapp-rapplication/1.0",
+                    })
+    # top-level neighborhood-flagship rapplications (e.g. the rapp-installer)
+    for d in sorted(glob.glob(os.path.join(CAVE, "rapplications", "*"))):
+        if os.path.isdir(d):
+            name = os.path.basename(d)
+            rapps.append({
+                "name": f"@kody-w/{name}", "version": "0.0.0", "schema": "rapp-rapplication/1.0",
+                "path": os.path.relpath(d, CAVE).replace(os.sep, "/") + "/",
+                "purpose": f"Cave flagship rapplication: {name}. Pull: curl -fsSL {RAW_PREFIX}/rapplications/{name}/bootstrap.sh | bash",
+            })
+    hdr = _load_header(os.path.join(CAVE, "rar", "index.json"), {
+        "schema": "rapp-rar-index/1.1",
+        "neighborhood_rappid": "rappid:@kody-w/rapp-cave:ca72ca0a3cb90c357fb09e38b02f85f09935cacbf61e94740c57f1eb30a73e0a",
+        "rar_for": "kody-w/RAPP (cave)", "kind": "public-workspace",
+        "raw_url_prefix": RAW_PREFIX,
+        "note": ("Public per-neighborhood registry. raw URLs require NO auth — anyone can stream. "
+                 "sha256 pins let `cave load` verify streamed files against this manifest."),
+    })
+    return {**hdr, "updated_at": _now(), "agents": agents, "rapps": rapps,
+            "verification": {"schema": "rapp-rar-manifest/1.0", "scheme": "sha256",
+                             "_instructions": "Re-compute sha256(file) for anything you stream and compare before installing."}}
+
+
+def _write(path: str, obj: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(obj, f, indent=2)
+        f.write("\n")
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    targets = {
+        os.path.join(CAVE, "super-rar", "index.json"): render_super_rar(),
+        os.path.join(CAVE, "rar", "index.json"): render_rar(),
+    }
+    drift = False
+    for path, obj in targets.items():
+        new = json.dumps({k: v for k, v in obj.items() if k not in ("built_at", "updated_at")},
+                         indent=2, sort_keys=True)
+        old = ""
+        if os.path.exists(path):
+            cur = json.load(open(path))
+            old = json.dumps({k: v for k, v in cur.items() if k not in ("built_at", "updated_at")},
+                             indent=2, sort_keys=True)
+        if new != old:
+            drift = True
+            print(f"{'DRIFT' if check else 'rebuilt'}: {os.path.relpath(path, CAVE)}")
+        if not check:
+            _write(path, obj)
+    sr = targets[os.path.join(CAVE, "super-rar", "index.json")]
+    print(f"super-RAR: {sr['count']} entries {sr['by_kind']}")
+    if check and drift:
+        print("super-RAR indexes are STALE — run `python3 cave/tools/build_super_rar.py`")
+        sys.exit(1)
+    if check:
+        print("super-RAR indexes are current ✓")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Gives the public RAPP Cave the **same super-RAR powers as the private batcave**, public (no auth).

**Before:** the cave shipped `rar/index.json` + `super-rar/index.json` (the index *files*) but not the engine that builds/streams them.

**Now:**
- `cave/tools/build_super_rar.py` — rebuilds RAR + super-store from the cubbies (the standalone equivalent of the god agent's `super_rar rebuild`); `--check` is the CI gate.
- `cave/agents/cave_agent.py` (`@kody-w/cave`) — drop-in `Cave` tool: `list` · `super_rar` · `load cubby=<login>` (streams a cubby's agents into your brainstem **git-invisibly** via `.git/info/exclude`, sha256-verified — zero commit risk) · `sync`.
- `cave/agents/rar_steward_agent.py` (`@rapp/rar_steward`) — registry hygiene.
- `.github/workflows/cave-super-rar.yml` — gates PRs so the super-store never drifts.
- `cave/specs/SUPER_RAR.md` — the spec.

**Verified end-to-end:** builder rebuild + `--check` pass; `Cave` agent `list`/`super_rar`/`load` tested — `load` streamed an agent in and it's absent from `git status` (git-invisible). Scoped to `cave/` + one workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)