### PR TITLE
docs(spec): correct stale constitutional anchor range I–XLVI -> I–LI

### DIFF
--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -4,7 +4,7 @@
 >
 > **Scope:** the **network protocol** — federation, addressing, discovery across the public web. **Not** the single-file agent contract; for that read [`pages/docs/SPEC.md`](../pages/docs/SPEC.md). See [`specs/README.md`](./README.md) for the spec-directory map.
 >
-> **Authority:** this file. **Schema-of-record:** `rapp-protocol/1.0`. **Constitutional anchor:** Articles I–XLVI (see `CONSTITUTION.md` in the parent project for narrative; this document is the operational synthesis).
+> **Authority:** this file. **Schema-of-record:** `rapp-protocol/1.0`. **Constitutional anchor:** Articles I–LI (see `CONSTITUTION.md` in the parent project for narrative; this document is the operational synthesis).
 
 ---
 
@@ -419,7 +419,7 @@ See `skill.md` (sibling file in this directory). It is the action-oriented runbo
 
 - **This spec:** `specs/SPEC.md` in the planted repo (frozen at planting time) and at `https://raw.githubusercontent.com/kody-w/RAPP/main/specs/SPEC.md` (canonical, evolving).
 - **Reference implementations:** `tools/door_address.py` (rappid parsing), `rapp_brainstem/agents/plant_seed_agent.py` (planter), `rapp_brainstem/agents/estate_agent.py` (estate), `tools/holo_card_generator.py` (holocard derivation).
-- **Constitutional anchor:** CONSTITUTION.md Articles I–XLVI in the parent project (`kody-w/RAPP`).
+- **Constitutional anchor:** CONSTITUTION.md Articles I–LI in the parent project (`kody-w/RAPP`).
 - **License:** spec text MIT; door content per its own license declaration in `card.json.meta.license`.
 
 ---


### PR DESCRIPTION
## What

`specs/SPEC.md` cited its **Constitutional anchor** as `Articles I–XLVI` in two places. The live `CONSTITUTION.md@main` has article headers running contiguously `0, I … LI` — the highest being **Article LI — Every Neighborhood Front Gate MUST Display A Tether QR** — with no gaps between XL and LI. The `I–XLVI` (46) range was therefore **stale by 5 articles**; the true max is **LI** (51).

This is corroborated inside `SPEC.md` itself, which already cites **Article XLVII** (L197) and **Article XLVIII** (L215) — making the `I–XLVI` range internally inconsistent.

These were the only two occurrences of the stale token repo-wide. No mirrored spec (`ecosystem-spec.json`) is touched.

## Changes (before -> after)

**`specs/SPEC.md` L7:**
- before: `**Constitutional anchor:** Articles I–XLVI (see \`CONSTITUTION.md\` in the parent project ...`
- after:  `**Constitutional anchor:** Articles I–LI (see \`CONSTITUTION.md\` in the parent project ...`

**`specs/SPEC.md` L422:**
- before: `**Constitutional anchor:** CONSTITUTION.md Articles I–XLVI in the parent project (\`kody-w/RAPP\`).`
- after:  `**Constitutional anchor:** CONSTITUTION.md Articles I–LI in the parent project (\`kody-w/RAPP\`).`

The en-dash (`–`, U+2013) is preserved in both. Only these two lines change.

Refs kody-w/RAPP#71