### PR TITLE
drift-fix 2026-07-08: H3 + M1 + M2 + M6 + L1 (RAPP species-root reconciliation)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -366,14 +366,14 @@ The 🌱 Propose-an-agent pane drafts a `BasicAgent` skeleton, accepts the visit
 
 Eggs are zip archives matching the `brainstem-egg/2.2-organism` schema. Two tiers (front door exports doorman; doorman exports ascended).
 
-> **Updated 2026-05-10:** the egg-cartridge family expanded. The `.egg` extension now carries five kinds, all addressable through the same kernel `egg_hatcher_agent.py` (introspects `manifest.schema`/`type`, routes by kind, refuses on unknown). See [`pages/docs/SPEC.md` §18.10](./pages/docs/SPEC.md) for the canonical family table and [`kody-w/rappterbox/carts/SCHEMA.md`](https://github.com/kody-w/rappterbox/blob/main/carts/SCHEMA.md) for the session-variant spec.
+> **Updated 2026-05-10:** the egg-cartridge family expanded. The `.egg` extension now carries five kinds. The kernel hatcher `egg_hatcher_agent.py` is the canonical `.egg` router (introspects `manifest.schema`/`type`, routes by **kind**, refuses on unknown) — per [`pages/docs/SPEC.md` §18.10.2](./pages/docs/SPEC.md). The `rapp-egg/2.0` **scale** dispatcher `twin_egg_hatcher_agent.py` (§15.5, [SPEC §18.10.5](./pages/docs/SPEC.md)) is an **additive superset** of that kind-router — every kind maps to a `scale` — not a competing hatcher. See [`pages/docs/SPEC.md` §18.10](./pages/docs/SPEC.md) for the canonical family table and [`kody-w/rappterbox/carts/SCHEMA.md`](https://github.com/kody-w/rappterbox/blob/main/carts/SCHEMA.md) for the session-variant spec.
 >
 > | Schema | Kind | Container | Hatch destination | Status |
 > |---|---|---|---|---|
 > | `brainstem-egg/2.2-organism` | `organism` | ZIP | `~/.rapp/twins/<rappid>/` | shipping |
 > | `brainstem-egg/2.2-rapplication` | `rapplication` | ZIP | planted rapp under host | shipping |
 > | `brainstem-egg/2.3-session` | `session` | JSON | rappterbox console iframe / `pages/vbrainstem.html` | shipping |
-> | `brainstem-egg/2.3-neighborhood` | `neighborhood` | ZIP | mint new GitHub repo / local mirror | planned |
+> | `brainstem-egg/2.3-neighborhood` | `neighborhood` | ZIP | mint new GitHub repo / local mirror | planned (public-substrate GitHub gate; the local-substrate LAN-snapshot form `rapp-egg/2.0 scale=neighborhood` ships — see §15.5 & SPEC §18.10.5) |
 > | `brainstem-egg/2.3-estate` | `estate` | ZIP | re-anchor whole identity on new substrate | planned |
 
 ### Doorman tier — anyone can export
@@ -626,13 +626,13 @@ Files added on demand:
 
 ## 15.5 Multi-scale eggs and the federation lifecycle
 
-§8 covers organism-scale eggs (`brainstem-egg/2.2-organism`) — one twin in, one twin out. The egg family generalizes: the `rapp-egg/2.0` envelope declares a `scale` field that picks one of five hatch destinations. The same `twin_egg_hatcher_agent.py` (canonical `@kody/twin_egg_hatcher` v1.1.0, RAR PR #98) introspects `manifest.scale` and dispatches per scale; unknown scales are refused outright (no silent fallback).
+§8 covers organism-scale eggs (`brainstem-egg/2.2-organism`) — one twin in, one twin out. The egg family generalizes: the `rapp-egg/2.0` envelope declares a `scale` field that picks one of five hatch destinations. `twin_egg_hatcher_agent.py` (canonical `@kody/twin_egg_hatcher` v1.1.0, RAR PR #98) introspects `manifest.scale` and dispatches **per scale**; unknown scales are refused outright (no silent fallback). This scale dispatcher is the **`rapp-egg/2.0` additive superset** of the kernel's `.egg` **kind**-router `egg_hatcher_agent.py` (§8, [SPEC §18.10.2/§18.10.5](./pages/docs/SPEC.md)) — every kind has a corresponding scale, so the two are one layered system, not two competing hatchers.
 
 | Scale | What it carries | Where it hatches | Status |
 |---|---|---|---|
 | `twin` | One twin's identity + soul + agents + memories | `~/.rapp/twins/<hash>/` | shipping |
 | `brainstem` | A whole brainstem distro (kernel + agents + organs) | target brainstem folder | shipping ([[The Distro Hatcher Agent Pattern]]) |
-| `neighborhood` | N federated twins + roster + member memories | `~/.rapp/twins/<hash>/` per member + `~/.rapp/neighborhoods/<hash>/` for the roster | shipping |
+| `neighborhood` | N federated twins + roster + member memories | `~/.rapp/twins/<hash>/` per member + `~/.rapp/neighborhoods/<hash>/` for the roster | shipping (local-substrate LAN snapshot; the public-substrate GitHub-gate form `brainstem-egg/2.3-neighborhood` is planned — see §8 & SPEC §18.10.1) |
 | `swarm` / `factory` / `industry` | Container scales above neighborhood | `~/.rapp/<scale>s/<hash>/` as best-effort scaffolding | partial — scale-specific handlers TBD |
 | `estate` | Whole operator identity: catalog + every nested twin / neighborhood cartridge + memories | recursive dispatch, restores `~/.brainstem/estate.json` | planned ([[ESTATE_SPEC]] §7.6) |
 

--- a/pages/chat.html
+++ b/pages/chat.html
@@ -14,9 +14,9 @@
   </style>
 </head>
 <body>
-  <h1>chat is now the grail brainstem (heimdall)</h1>
+  <h1>chat — the vbrainstem core surface</h1>
   <p>Redirecting you to <span id="dest">…</span></p>
-  <p><small>Per "use this as the grail brainstem: kody-w/heimdall" — heimdall's index.html IS the canonical browser brainstem and already supports embodying any twin via <code>?seed=&lt;owner&gt;/&lt;repo&gt;</code>. We stopped rebuilding it.</small></p>
+  <p><small>Canon: <strong>vbrainstem</strong> is the browser brainstem runtime; <strong>Heimdall</strong> is a doorman <em>posting</em> that runs on it — real estate, not software. This page routes to the deployed reference posting, which embodies any twin via <code>?seed=&lt;owner&gt;/&lt;repo&gt;</code>. Any twin's DOG can stand at a door like this one.</small></p>
   <p style="margin-top: 30px;"><a id="manual" href="/RAPP/pages/summon.html">Tap a twin in the summon portal →</a></p>
   <script>
     // If the user previously summoned a twin, vbs_rappid is in localStorage.

--- a/pages/tether.html
+++ b/pages/tether.html
@@ -1493,8 +1493,10 @@ function closeRapp() {
 const tphoneCall = { startedAt: 0, durTimer: 0 };
 
 function parseNbhdCoords(rappid) {
-  // Eternity rappid:@<owner>/<slug>:<hash> (legacy forms read-compatible)
-  const m = (rappid || '').match(/@[^/]+\/([^/]+)\/(.+)$/);
+  // Eternity rappid:@<owner>/<slug>:<hash> (single slash, colon-terminated hash).
+  // Tolerant of legacy @<owner>/<repo>/<hash> and @<owner>/<repo>:<hash>@host too:
+  // owner + slug are just the first two @-anchored path segments.
+  const m = (rappid || '').match(/@([^/]+)\/([^/:]+)/);
   if (!m) return null;
   return { owner: m[1], repo: m[2] };
 }
@@ -2633,7 +2635,7 @@ async function ghPutFile(pat, owner, repo, path, content, msg) {
 
 function buildGrailFor(handle, rappid) {
   const now = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
-  const hash = rappid.match(/:([a-f0-9]+)@/)?.[1] || '';
+  const hash = rappid.match(/:([a-f0-9]+)(?:@|$)/)?.[1] || '';
   return {
     'rappid.json': JSON.stringify({
       schema:    'rapp-rappid/2.0',
@@ -2760,7 +2762,7 @@ function operatorFrontGateHtml(handle, rappid) {
         } catch (e) { return null; }
       }
       function toIncantation(rappid, words) {
-        const m = rappid.match(/:([a-f0-9]+)@/);
+        const m = rappid.match(/:([a-f0-9]+)(?:@|$)/);
         if (!m || !words || words.length !== 1024) return null;
         let seed = BigInt('0x' + m[1].slice(0, 16).padEnd(16, '0'));
         const o = [];
@@ -3293,7 +3295,7 @@ function installBridgeListener() {
 }
 
 function lobbyIdsFor(nbhd) {
-  const m = (nbhd?.rappid || '').match(/:([a-f0-9]+)@/);
+  const m = (nbhd?.rappid || '').match(/:([a-f0-9]+)(?:@|$)/);
   const h = m ? m[1].slice(0, 16) : 'unknown';
   return { hostId: `rapp-${h}-host`, prefix: `rapp-${h}` };
 }

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -192,13 +192,11 @@ The Charizard floor: two devices with no shared network at all. Just file exchan
 
 ### §4.6 Discoverability — publishing IS the signal (no central registry)
 
-### §4.6 Discoverability — publishing IS the signal (no central registry)
-
 Constitutional anchor: **CONSTITUTION Article XLVII**.
 
 The network has no registry. Becoming part of the federation = publishing your estate per spec. Three artifacts compose discovery:
 
-1. **Beacon** — `https://raw.githubusercontent.com/<handle>/rapp-estate/main/.well-known/rapp-network.json` — schema `rapp-network-beacon/1.0`. Carries: operator rappid, estate URL, protocol versions, `discovery.indexable` (consent flag — robots.txt style; default true), `discovery.federation_hints` (other operator handles you know about).
+1. **Beacon** — `https://raw.githubusercontent.com/<handle>/rapp-estate/main/.well-known/rapp-network.json` — schema `rapp-network-beacon/1.1`. Carries: operator rappid, estate URL, protocol versions, `discovery.indexable` (consent flag — robots.txt style; default true), `discovery.federation_hints` (other operator handles you know about), and the three REQUIRED private-extension fields `private_estate_pointer` + `private_estate_commitment` + `private_door_count` (§4.7, Article XLVIII — a beacon without them is flagged `compliance: legacy`).
 2. **Seed** — `https://raw.githubusercontent.com/kody-w/RAPP/main/.well-known/rapp-network-seed.json` — schema `rapp-network-seed/1.0`. Lists known operators as the BFS starting set. Convenient but not authoritative; anyone can fork the species root and host their own seed.
 3. **Sniffer** — `tools/sniff_network.py`. Default mode: BFS from seed across beacons via raw URLs only (no GitHub Search API; no rate limits). Returns `rapp-network-sniff/1.0` envelope.
 
@@ -233,7 +231,7 @@ A beacon WITHOUT these is non-compliant. Sniffers flag such operators as `compli
 
 ### §4.8 No fallbacks; spec says what's true
 
-- A rappid that doesn't match v2 format, OR whose two `<owner>/<repo>` segments disagree, OR whose kind is not in §2.1 → INVALID → consumer raises an error.
+- A rappid that doesn't match the consolidated Eternity form `rappid:@<owner>/<slug>:<64hex>` (§2) — after canonicalizing any legacy form via `door_address.py` — OR whose `kind` (read from the `rappid.json` record) is not in §2.1 → INVALID → consumer raises an error.
 - An estate entry with stored derived fields → leakage; on next save those fields are dropped.
 - A door missing any of §3's required canonical files → non-compliant; the planter (or the backfill) emits the missing file rather than the consumer "best-efforting" around it.
 

--- a/specs/ecosystem-spec.json
+++ b/specs/ecosystem-spec.json
@@ -1,6 +1,6 @@
 {
   "schema": "rapp-ecosystem-spec/1.0",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "The RAPP Ecosystem — Full End-to-End Spec",
   "summary": "The single canonical description of the entire RAPP ecosystem: every operator capability domain, the one agent that drives them via natural language, the schemas, the repos, the end-to-end journeys, and the four-leg drift triangle that keeps this spec, the agent, and the two mirror repos in sync.",
   "canonical_source": "kody-w/RAPP",
@@ -1494,6 +1494,8 @@
       "rapp-vscode-extension"
     ],
     "identity & registry": [
+      "rapp-eternity (identity authority — the sole identity standard; schema rapp-eternity/1.0; rapp-rappid-spec/2.0 defers to it)",
+      "rapp-estate (estate spec/template — the Constitutionally-mandated <handle>/rapp-estate public + <handle>/rapp-estate-private family, Art. XLVIII; schema rapp-estate/1.1)",
       "rapp-god (registry of every part + version; drift observatory; hosts this spec)",
       "rapp-map (which repo houses which part; hosts this spec; the neuron mesh)",
       "RAR (single-file agent registry)",
@@ -1519,7 +1521,8 @@
       "rapp-vneighborhood (template)",
       "rapp-commons (global town square)",
       "rapp-god-forum",
-      "rapp-resident (cloud relay)"
+      "rapp-resident (cloud relay)",
+      "RAPP-Network (project-twin neighborhood layer)"
     ],
     "the agent-built web": [
       "rionet (rapp.robots.txt → rappbot → RIO)",


### PR DESCRIPTION
Ecosystem reconciliation — the **RAPP (species-root)** share of the 2026-07-08 full-mesh drift sweep (verdict DRIFT-FOUND, 13 mesh findings). One commit per logical fix, preserved via a **merge** commit (not squash).

## Findings fixed here
- **H3** — `pages/chat.html`: heimdall reclassified as a doorman posting on the **vbrainstem** runtime (cortex ruling); vbrainstem stays the canonical browser brainstem per `ecosystem-spec.json`. `Closes #76`
- **M1** — `specs/SPEC.md`: beacon schema `1.0`→`1.1` + the three REQUIRED private-extension fields, dedup the duplicated §4.6 header, and §4.8 bullet 1 → single-segment Eternity validation (drops the retired v2 / two-owner-segment shape). `Closes #77`
- **M2** — `specs/ecosystem-spec.json`: the Constitutionally-mandated `rapp-estate` family (Art. XLVIII: `<handle>/rapp-estate` + `<handle>/rapp-estate-private`) added to the repos catalog. `Closes #78`
- **M6** — `pages/tether.html`: the 4 legacy parse regexes now accept the Eternity `rappid:@<owner>/<slug>:<hash>` form the file itself mints (`buildGrailFor` emits a non-empty hash; `openTphoneCall` resolves owner/repo). `Closes #79`
- **L1** — `ECOSYSTEM.md`: §8 vs §15.5 egg-hatch domain reconciled to the canonical `pages/docs/SPEC.md` §18.10 — two layers (kernel `.egg` kind-router + `rapp-egg/2.0` scale-dispatcher superset), neighborhood status split by substrate. `Closes #80`

## Also underpinned by the species-root spec amendment (`5a71151`, `version` → 1.1.0)
The same commit adds `RAPP-Network` and `rapp-eternity` to the repos catalog — those findings are closed by their owning repos:
- Refs kody-w/RAPP-Network#3 (H2)
- Refs kody-w/rapp-egg-hub#7 (M3)

The amended spec was propagated **byte-identical** to `rapp-god` + `rapp-map` (sha256 `fc9c622e…`). The H3 ruling required **no re-propagation** — the spec's `repos["run a brainstem"]` was unchanged by the ruling.

**Commits (preserved):** `5a71151` · `2dc6c8d` · `24e37de` · `3c25d53` · `cafe537` (H3, cortex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
