### PR TITLE
drift(R2): species-root ecosystem-spec 1.1.1 identity fix + internal-doc reconciliation

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -3383,6 +3383,8 @@ The estate is the door catalog. Each user's `~/.brainstem/estate.json` (and its 
 
 Authority for the spec: `pages/docs/ESTATE_SPEC.md`. Conformance gate: `tests/features/F13-estate-spec.sh`.
 
+> **Amendment (2026-07-08) — format supersession, additive per Article XXVI.** Sub-sections below that still speak of "the v2 rappid" / "the v2 format" / "the v2 door rappid" / "two `<owner>/<repo>` segments" (XLVI.1, XLVI.5, XLVI.7 #1, and the echo in XLIX.1) are **superseded by Article XXXIV.1's format lock (2026-06-03)**, matching this article's own intro above. The ONE minted and validated door-bearing form is the consolidated Eternity `rappid:@<owner>/<slug>:<64hex>` — a **single** `@<owner>/<slug>` location segment, a 64-hex identity/join key, with `kind` in the `rappid.json` record (never the string). The legacy `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/...` is **read-forever and canonicalized on read** (`tools/door_address.py::canonicalize_rappid`), **never emitted**. Read XLVI.5's validity gate accordingly: `door_from_rappid()` MUST accept the consolidated Eternity form and canonicalize legacy v2 — it MUST NOT reject a rappid merely for "not being v2." Identity is `rapp-eternity/1.0` (the sole identity standard, to which `rapp-rappid/2.0` defers). The stale wording is preserved (Article XXVI: additive-only, no removals) but does not govern; this note governs.
+
 ### XLVI.1 — Rappid Determines URL
 
 The v2 rappid encodes its own GitHub origin. Every canonical URL the door has — `repo`, `front`, `identity`, `holocard`, `holo_md`, `avatar`, `summon_qr`, `members`, `facets` — is derivable from the rappid string alone, by parsing. No lookup. No config. No env. The parser is `door_from_rappid()` in `tools/door_address.py`. There is exactly one parser. Consumers MAY NOT reimplement; they MUST import.
@@ -3487,6 +3489,8 @@ The door-less tier's canonical form is the **RAPP Eternity Standard** — the sc
 The Estate Spec (Article XLVI) made the rappid the global address. Article XLVI.6 made the estate recomputable from the network. **Article XLVII makes the network itself discoverable without a central authority.**
 
 This is the platform's most decentralized layer. Three primitives compose it:
+
+> **Amendment (2026-07-08) — beacon schema, additive per Article XXVI.** The beacon schema references below that still read `rapp-network-beacon/1.0` (in this XLVII.1 primitive and in the "What this article requires" list) are **bumped to `rapp-network-beacon/1.1`** by Article XLVIII (which adds the REQUIRED private-extension fields `private_estate_pointer` + `private_estate_commitment` + `private_door_count`), corroborated by XLVII.5.1's own TXT schema (`schema = "rapp-network-beacon/1.1"`). The winning value everywhere is `rapp-network-beacon/1.1`; the `1.0` mentions are preserved (additive-only) but superseded.
 
 1. **The well-known beacon.** Every published estate ships a `.well-known/rapp-network.json` at the root of the operator's `<handle>/rapp-estate` repo, fetchable at `https://raw.githubusercontent.com/<handle>/rapp-estate/main/.well-known/rapp-network.json`. Schema: `rapp-network-beacon/1.0`. Contents: operator rappid, estate URL, protocol versions implemented, `discovery.indexable` (the consent flag — defaults true; honored like robots.txt's `Disallow`), and `discovery.federation_hints` (a list of other operator handles this operator is aware of).
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -83,7 +83,7 @@ Per-user private memories live in **GitHub Issues** on the seed repo (label `pri
 
 ## 3. Identity stack — everything traces back to the rappid
 
-All visual and computed properties of an organism derive from a single UUIDv4 `rappid` minted at first plant. This is the species identity contract — the rappid IS the organism, every visual is a refraction of it.
+All visual and computed properties of an organism derive from a single `rappid` minted at first plant — the consolidated Eternity string `rappid:@<owner>/<slug>:<64hex>` (`rapp-rappid/2.0`; the 64-hex is the identity hash and sole join key, `kind` in the record). This is the species identity contract — the rappid IS the organism, every visual is a refraction of it.
 
 ```
                               rappid (UUIDv4)
@@ -424,7 +424,7 @@ The 🔬 Verify pane on the front door recomputes everything client-side. Three 
 - ⚠ **partial** — missing or unexpected files
 - ✗ **tampered** — at least one file edited offline
 
-Plus 🌐 **Deep-verify against live repo** — re-fetches every file from `raw.githubusercontent.com/<owner>/<repo>/<sealed_sha>/<path>` and recomputes hashes. If matches: provably authentic, since only the seed's owner can push to the public repo. (This sidesteps phase-2 ed25519 signatures by leaning on GitHub push-permission as the trust anchor — see §11 for the airplane-mode picture.)
+Plus 🌐 **Deep-verify against live repo** — re-fetches every file from `raw.githubusercontent.com/<owner>/<repo>/<sealed_sha>/<path>` and recomputes hashes. If matches: provably authentic, since only the seed's owner can push to the public repo. (GitHub push-permission + sha256 is the primary trust anchor here; ed25519 publisher signatures — shipped 2026-05-08 per CONSTITUTION Art. XXXIV.7 — stay scoped to the offline-only fallback tier and are optional, never mandatory. See §11 for the airplane-mode picture.)
 
 ---
 
@@ -484,7 +484,7 @@ The egg's `state_at_seal` block is a third tier of fallback — for organisms th
 | Online | `raw.githubusercontent.com/<owner>/<repo>/main/...` | Only operator can push |
 | Airplane | localStorage cache stamped with last-sync date | Stale but real signature of last-known state |
 | Hatched offline | egg manifest `state_at_seal` + `provenance.file_hashes` | Self-describing; sha256 chain catches tampering |
-| Phase 2 (future) | ed25519 publisher signatures | Required for offline-only chains where neither GitHub nor recent cache is available |
+| Offline-only | ed25519 publisher signatures (shipped 2026-05-08, Art. XXXIV.7) | Optional fallback for chains where neither GitHub nor recent cache is available — never mandatory |
 
 ---
 

--- a/ECOSYSTEM_MAP.md
+++ b/ECOSYSTEM_MAP.md
@@ -136,9 +136,9 @@ Every `rapp-*/N.M` and `brainstem-*/N.M-variant` currently emitted in the repo. 
 | Schema | Purpose | Defined in | Emitted by |
 |---|---|---|---|
 | `rapp-agent/1.0` | Agent module manifest (function-calling shape) | pages/docs/SPEC.md | every `*_agent.py` metadata dict |
-| `rapp-rappid/1.1` | Organism birth certificate (legacy schema) | ECOSYSTEM §3 | installer/plant.sh, twin_agent.py `_summon` |
-| `rapp-rappid/2.0` | Birth certificate + kernel + bonds (current) | CONSTITUTION; vault/Architecture/Rappid | utils/bond.py, rappid.json |
-| `rapp-card/1.0` | Trade-card override | ECOSYSTEM §3 | card.json (operator-set) |
+| `rapp-rappid/1.1` | Organism birth certificate (legacy schema) | ECOSYSTEM §3 | legacy — no active emitter; read-compat only, retained per Art. XXXIV.5 (never regenerate) |
+| `rapp-rappid/2.0` | Birth certificate + kernel + bonds (current) | CONSTITUTION; vault/Architecture/Rappid | utils/bond.py, rappid.json, installer/plant.sh, twin_agent.py `_summon` |
+| `rapp-card/1.0` | Trade-card override — the operator-set **subset** layered inside the full `rappcards/1.1.2` `card.json` holocard (SPEC.md §5); distinct layers, not competing schemas | ECOSYSTEM §3 | card.json (operator-set) |
 | `rapp-frame/1.0` | Mutation event (content-addressed sha256, prev_hash chain) | ECOSYSTEM §3, HERO_USECASE §2 | installer/plant.sh::appendFrame → localStorage `rapp_frames_v1`; ascended egg packs `data/frames.json` |
 | `brainstem-egg/2.0` | Legacy twin egg | utils/egg.py | (legacy) |
 | `brainstem-egg/2.1` | Variant repo cartridge | CLAUDE.md egg formats | utils/bond.py, twin_agent.py |

--- a/pages/docs/ESTATE_SPEC.md
+++ b/pages/docs/ESTATE_SPEC.md
@@ -40,7 +40,7 @@ Every planted door MUST be reachable at these URLs. The planter MUST emit each o
 |---|---|---|---|
 | 1 | `repo` | `https://github.com/<owner>/<repo>` | all (the canonical browsing URL) |
 | 2 | `front` | `https://<owner>.github.io/<repo>/` | all (the heimdall snapshot — the operator-facing chat surface) |
-| 3 | `identity` | `https://raw.githubusercontent.com/<owner>/<repo>/main/rappid.json` | all (`rapp-rappid/2.0`) |
+| 3 | `identity` | `https://raw.githubusercontent.com/<owner>/<repo>/main/rappid.json` | all (`rapp-rappid/2.0`, which defers to `rapp-eternity/1.0` — the sole identity standard) |
 | 4 | `holocard` | `https://raw.githubusercontent.com/<owner>/<repo>/main/card.json` | all (`rappcards/1.1.2`) |
 | 5 | `holo_md` | `https://raw.githubusercontent.com/<owner>/<repo>/main/holo.md` | all (the friendly entry doc) |
 | 6 | `avatar` | `https://raw.githubusercontent.com/<owner>/<repo>/main/holo.svg` | all (procedural sprite) |
@@ -160,10 +160,26 @@ def door_from_rappid(rappid: str) -> dict:
       }
 
     Raises:
-      InvalidRappidError if the string is not a valid v2 rappid OR if the
-      <owner>/<repo> appears differently in the two segments.
+      InvalidRappidError only if the string is genuinely malformed (no parseable
+      @<owner>/<slug>:<hash> and no canonicalizable legacy form). It MUST ACCEPT
+      the consolidated Eternity form `rappid:@<owner>/<slug>:<64hex>` (one
+      location segment) and MUST canonicalize every legacy form on read (v2
+      `rappid:v2:<kind>:@<owner>/<repo>:<32hex>@github.com/...`, bare UUID, bare
+      `rappid:<slug>:<64hex>`) via `canonicalize_rappid()` before deriving — it
+      MUST NOT reject a rappid merely for "not being v2".
     """
 ```
+
+> **Amendment (2026-07-08, per CONSTITUTION Art. XXXIV.1 lock 2026-06-03).** An
+> earlier draft of this Raises clause read "*if the string is not a valid v2
+> rappid OR if the `<owner>/<repo>` appears differently in the two segments*."
+> That is superseded: the canonical consolidated Eternity form has ONE
+> `@<owner>/<slug>` segment (not two) and is not a "v2 rappid", so the old clause
+> would reject every currently-mintable rappid. The contract now validates the
+> Eternity form and read-forever-canonicalizes legacy v2 (never emitting it),
+> matching the reference `tools/door_address.py` (`parse_rappid` /
+> `canonicalize_rappid`). Identity is `rapp-eternity/1.0` — the sole identity
+> standard, to which `rapp-rappid/2.0` defers.
 
 Implementation lives at `tools/door_address.py`. Imported by `plant_seed_agent.py`, `estate_agent.py`, and any future federation/discovery consumer. One implementation, one contract — no per-consumer reinventions.
 
@@ -371,6 +387,8 @@ Authority: [`pages/docs/PUBLIC_PRIVATE_BOUNDARY.md`](./PUBLIC_PRIVATE_BOUNDARY.m
 - **`rapp_brainstem/agents/estate_agent.py`** — the local-first agent that reads/writes the estate.
 - **`rapp_brainstem/agents/plant_seed_agent.py`** — the planter that emits the Door URL Set on every new plant.
 - **`rapp_brainstem/agents/twin_egg_hatcher_agent.py`** — the universal hatcher dispatched per `rapp-egg/2.0` scale (twin / brainstem / neighborhood / swarm / factory / industry / estate).
+
+> **Serving-surface note (2026-07-08).** The estate / plant / hatch capabilities are canonically driven as **actions on the one agent** (`@rapp/rapp` — e.g. `estate`, `door`, `whoami`, `hatch`) plus RAR-distributed specialists, not as standalone kernel files at fixed paths. Two hatcher layers coexist (per `pages/docs/SPEC.md` §18.10 / `ECOSYSTEM.md` §15.5): the kernel `.egg` **kind**-router `egg_hatcher_agent.py` and the `rapp-egg/2.0` **scale**-dispatcher `@kody/twin_egg_hatcher` (`twin_egg_hatcher_agent.py`, RAR PR #98, the canonical hatcher per §7.5.2) — an additive superset, not a competitor. Treat the `*_agent.py` filenames above as role labels; resolve the live serving agent through RAR / the one-agent action surface.
 - **[[The Federated Twin Egg Hatcher Pattern]]** — the kernel-side pattern that makes neighborhood-scale federations operable; canonical home of the four-twin AIBAST worked example.
 - **[[NEIGHBORHOOD_PROTOCOL]] §5e** — the on-the-wire format for neighborhood-scale cartridges; §7.5.2 of this spec is the addressing-layer view of the same artifact.
 - **[[The Swarm Estate]]** — the cryptographic backing (M/S/U/D cross-signing) that travels inside each member's `.brainstem_data/` when an estate cartridge migrates substrates.

--- a/specs/SPEC.md
+++ b/specs/SPEC.md
@@ -243,6 +243,8 @@ This is constitutionally enforced (Article XLVI.5) because the alternative — p
 
 Every door has a `card.json` at `https://raw.githubusercontent.com/<owner>/<repo>/main/card.json`. Schema: `rappcards/1.1.2`.
 
+> **Schema note (card layers).** `rappcards/1.1.2` is the **full `card.json` holocard schema** — the entire door-file. It is distinct from the `rapp-card/1.0` primitive in `ECOSYSTEM_MAP.md §5`, which is the **operator-set override subset** (the fields an operator hand-tunes) layered inside the same `card.json`. They are two layers of one file, not competing schemas; do not unify the identifiers.
+
 ### §5.1 Required fields
 
 ```json

--- a/specs/ecosystem-spec.json
+++ b/specs/ecosystem-spec.json
@@ -1,6 +1,6 @@
 {
   "schema": "rapp-ecosystem-spec/1.0",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "title": "The RAPP Ecosystem — Full End-to-End Spec",
   "summary": "The single canonical description of the entire RAPP ecosystem: every operator capability domain, the one agent that drives them via natural language, the schemas, the repos, the end-to-end journeys, and the four-leg drift triangle that keeps this spec, the agent, and the two mirror repos in sync.",
   "canonical_source": "kody-w/RAPP",
@@ -12,7 +12,7 @@
     "code"
   ],
   "first_principle": "use everyone else's hardware to run the network",
-  "identity_format": "Eternity rappid:@<owner>/<slug>:<64hex>  (sha256 of '<owner>/<slug>'; kind lives in the record, not the string; CONSTITUTION Art. XXXIV.1, locked 2026-06-03). Legacy v2 is read-forever and canonicalized, never emitted.",
+  "identity_format": "Eternity rappid:@<owner>/<slug>:<64hex>  (64hex = sha256 of the master public key for keyed organisms, or a stable UUID/commit-derived hash for keyless; independent of the slug — the hash is the join key, never the slug; kind lives in the record, not the string; CONSTITUTION Art. XXXIV.1/XXXVI.1, locked 2026-06-03). Legacy v2 is read-forever and canonicalized, never emitted.",
   "mirrors": {
     "note": "This exact JSON is published byte-identical to two independent grail repos. Divergence between them IS drift — the agent's `verify` action sha256-compares them.",
     "rapp_god": "https://raw.githubusercontent.com/kody-w/rapp-god/main/api/v1/ecosystem-spec.json",


### PR DESCRIPTION
# drift(R2) reconciliation — species-root spec + internal docs

Round-2 drift fixes for the canonical repo. **THE LAW** governing every identity finding (cortex-adjudicated from CONSTITUTION Art. XXXIV.1 / XXXVI.1 + `pages/vault/Architecture/Rappid.md`): the rappid **64hex** is `sha256(master_pubkey_SPKI)` for keyed organisms, or a **stable UUID/commit-derived** hash for keyless ones — **NEVER** `sha256("<owner>/<slug>")`. The hash is the join key; the slug is location sugar; `kind` lives in the record, not the string.

## Findings fixed (one commit each)

| Commit | Finding | What |
|--------|---------|------|
| `c186da7` | **R2-01** | `specs/ecosystem-spec.json` `identity_format` parenthetical corrected to the canon keyless-hash text (no longer "sha256 of '<owner>/<slug>'"); content bump **1.1.0 → 1.1.1**. Propagated byte-identical to the rapp-god + rapp-map mirrors (their own PRs). |
| `f2f632d` | **R2-01 (secondary)** | `specs/SPEC.md` §5: document the card-schema **layering** — `rappcards/1.1.2` (full holocard) vs `rapp-card/1.0` (operator-set override subset) are distinct layers by design, not a conflict. |
| `6d8cdab` | **R2-05** | `ECOSYSTEM_MAP.md` §5: rappid emitter rows moved to the `rapp-rappid/2.0` (Eternity) row; card-layer note on the `rapp-card/1.0` row. |
| `63d45e9` | **R2-04** | `ECOSYSTEM.md`: ed25519 signing/trust shown as **shipped**, not phase-2/future (§3, §9, §11 matrix) — matches the live trust surface. |
| `ae1fe70` | **R2-09** | `pages/docs/ESTATE_SPEC.md`: `door_from_rappid` **Raises** on a legacy string that fails to canonicalize; `rapp-eternity/1.0` identity-standard cross-reference added. |
| `9d289e7` | **R2-06** | `CONSTITUTION.md`: the Constitution is **append-only** (Art. XXVI) — reconciled via **dated clarification** blockquotes (established pattern) on Article XLVI (v2 → Eternity consolidation) and Article XLVII (beacon 1.0 → 1.1). No normative text removed. |

## Issues closed by this PR

Closes #84
Closes #85
Closes #86
Closes #87
Closes #88

R2-02 (rapp-map#5) and R2-03 (rapp-god#6) are the byte-identical mirror re-renders of the 1.1.1 spec — delivered in their own repos' PRs, cross-referenced back here.

## Gates

- `specs/ecosystem-spec.json` valid JSON, `version == 1.1.1`; byte-identical (`sha256 de2ba267…`) across RAPP / rapp-god / rapp-map.
- No `sha256("<owner>/<slug>")` identity claim remains on any changed surface.
- (Pre-existing, unrelated) `node tests/run-tests.mjs` is broken by a missing distro asset — filed separately as #90, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code).
